### PR TITLE
Replace `vBuild()` with `buildPartial()` for the incomplete `UserLoggedIn` message in the `SessionsContextSpec` test

### DIFF
--- a/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/SessionsContextSpec.kt
+++ b/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/SessionsContextSpec.kt
@@ -64,8 +64,9 @@ public class SessionsContextSpec : ContextAwareTest() {
         public fun `emit 'UserLoggedIn' event`() {
             val expected = with(UserLoggedIn.newBuilder()) {
                 id = session
-                buildPartial() /* The `PersonalAccessToken` value is omitted because
-                it has no effect on the entity's behavior. */
+                // Building the message partially to include
+                // only the tested fields.
+                buildPartial()
             }
             val events = assertEvents(UserLoggedIn::class.java)
             events.hasSize(1)

--- a/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/SessionsContextSpec.kt
+++ b/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/SessionsContextSpec.kt
@@ -64,7 +64,8 @@ public class SessionsContextSpec : ContextAwareTest() {
         public fun `emit 'UserLoggedIn' event`() {
             val expected = with(UserLoggedIn.newBuilder()) {
                 id = session
-                vBuild()
+                buildPartial() /* The `PersonalAccessToken` value is omitted because
+                it has no effect on the entity's behavior. */
             }
             val events = assertEvents(UserLoggedIn::class.java)
             events.hasSize(1)


### PR DESCRIPTION
This changeset replaces `vBuild()` with `buildPartial()` for the incomplete `UserLoggedIn` message in the `SessionsContextSpec` test. 

The `token` field is ignored when building `UserLoggedIn`, which has no effect on the behavior of the `UserSession` entity.