### PR TITLE
Configure the continuous integration flow and change JDK version to 11

### DIFF
--- a/.github/workflows/build-under-ubuntu.yml
+++ b/.github/workflows/build-under-ubuntu.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 11
           distribution: temurin
 
       - name: Configure Gradle options

--- a/.github/workflows/build-under-ubuntu.yml
+++ b/.github/workflows/build-under-ubuntu.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           java-version: 17
           distribution: zulu
-          cache: gradle
 
       - name: Build and run tests
         run: ./gradlew build --stacktrace

--- a/.github/workflows/build-under-ubuntu.yml
+++ b/.github/workflows/build-under-ubuntu.yml
@@ -18,8 +18,5 @@ jobs:
           java-version: 11
           distribution: temurin
 
-      - name: Configure Gradle options
-        run: export GRADLE_OPTS="$GRADLE_OPTS --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED"
-
       - name: Build and run tests
         run: ./gradlew build --stacktrace

--- a/.github/workflows/build-under-ubuntu.yml
+++ b/.github/workflows/build-under-ubuntu.yml
@@ -1,0 +1,23 @@
+name: Build under Ubuntu
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: zulu
+          cache: gradle
+
+      - name: Build and run tests
+        run: ./gradlew build --stacktrace

--- a/.github/workflows/build-under-ubuntu.yml
+++ b/.github/workflows/build-under-ubuntu.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up JDK 17
+      - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           java-version: 11

--- a/.github/workflows/build-under-ubuntu.yml
+++ b/.github/workflows/build-under-ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 17
-          distribution: zulu
+          distribution: temurin
 
       - name: Configure Gradle options
         run: export GRADLE_OPTS="$GRADLE_OPTS --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED"

--- a/.github/workflows/build-under-ubuntu.yml
+++ b/.github/workflows/build-under-ubuntu.yml
@@ -18,5 +18,8 @@ jobs:
           java-version: 17
           distribution: zulu
 
+      - name: Configure Gradle options
+        run: export GRADLE_OPTS="$GRADLE_OPTS --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED"
+
       - name: Build and run tests
         run: ./gradlew build --stacktrace

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Currently, this is a work-in-progress example.
 
 ## Tech
 
-* JDK 17.
+* JDK 11.
 * Spine Event Engine.
 * Kotlin, TypeScript.
 * Google Cloud.

--- a/buildSrc/src/main/kotlin/io/spine/internal/BuildSettings.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/BuildSettings.kt
@@ -36,6 +36,6 @@ import org.gradle.jvm.toolchain.JavaLanguageVersion
  */
 public object BuildSettings {
 
-    private const val JVM_VERSION = 17
+    private const val JVM_VERSION = 11
     public val javaVersion: JavaLanguageVersion = JavaLanguageVersion.of(JVM_VERSION)
 }


### PR DESCRIPTION
This changeset adds a GitHub Actions workflow that automatically builds the project whenever a PR is made to `master` branch. Also is changed JDK version from 17 to 11 for compatibility with Gradle 6.9.4.