### PR TITLE
Remove useless comments from mention testing and rename methods that create `BoundedContextBuilder`s

### DIFF
--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubClientProcess.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubClientProcess.kt
@@ -62,7 +62,6 @@ public class GitHubClientProcess :
      */
     @React
     internal fun on(@External event: UserLoggedIn): GitHubTokenUpdated {
-        archived = true
         builder().setToken(event.token)
         return GitHubTokenUpdated.newBuilder()
             .setId(GitHubClientId::class.buildBy(event.id.username))
@@ -99,7 +98,6 @@ public class GitHubClientProcess :
      */
     @React
     internal fun on(event: MentionsUpdateFromGitHubRequested): List<EventMessage> {
-        archived = true
         val username = state().id.username
         val token = state().token
         val mentions = gitHubClientService.fetchMentions(username, token)

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/MentionsContext.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/MentionsContext.kt
@@ -45,6 +45,6 @@ public const val NAME: String = "Mentions"
  * Therefore, an instance of GitHub client is required
  * as a parameter.
  */
-public fun newBuilder(gitHubClientService: GitHubClientService): BoundedContextBuilder =
+public fun newMentionsContext(gitHubClientService: GitHubClientService): BoundedContextBuilder =
     BoundedContext.singleTenant(NAME)
         .add(GitHubClientRepository(gitHubClientService))

--- a/mentions/src/test/kotlin/io/spine/examples/pingh/mentions/GitHubClientSpec.kt
+++ b/mentions/src/test/kotlin/io/spine/examples/pingh/mentions/GitHubClientSpec.kt
@@ -63,10 +63,6 @@ public class GitHubClientSpec : ContextAwareTest() {
     protected override fun contextBuilder(): BoundedContextBuilder =
         newBuilder(gitHubClientService)
 
-    /**
-     * Creates the [BlackBoxContext] of the Sessions bounded context,
-     * and further emits of the [UserLoggedIn] event in the Sessions context.
-     */
     @BeforeEach
     public fun prepareSessionsContextAndEmitEvent() {
         sessionContext = BlackBoxContext
@@ -76,10 +72,6 @@ public class GitHubClientSpec : ContextAwareTest() {
         emitUserLoggedInEventInSessionsContext()
     }
 
-    /**
-     * Creates a new token and emits the [UserLoggedIn] event
-     * in the Sessions bounded context.
-     */
     private fun emitUserLoggedInEventInSessionsContext() {
         token = PersonalAccessToken::class.buildBy(randomString())
         val userLoggedIn = UserLoggedIn::class.buildBy(gitHubClientId.username, token)
@@ -125,46 +117,28 @@ public class GitHubClientSpec : ContextAwareTest() {
             context().assertEvent(expected)
         }
 
-        /**
-         * Checks that the value of the `when_started` field is different from the default,
-         * i.e. has been set to some value.
-         *
-         * [MentionsUpdateFromGitHubRequested] command is sent from another thread,
-         * and the main thread checks the state of the entity while performing the update.
-         */
         @Test
-        public fun `set the start time of the updating operation`() {
-            val otherClientTread = Thread {
+        public fun `set the start time of the update operation`() {
+            val otherClientThread = Thread {
                 val command = UpdateMentionsFromGitHub::class.buildBy(gitHubClientId)
                 context().receivesCommand(command)
             }
             val gitHubClientWithDefaultWhenStartedField =
                 GitHubClient::class.buildWithDefaultWhenStartedField()
             try {
-                otherClientTread.start()
+                otherClientThread.start()
                 context().assertState(gitHubClientId, GitHubClient::class.java)
                     .ignoringFields(listOf(1, 2))
                     .isNotEqualTo(gitHubClientWithDefaultWhenStartedField)
             } finally {
-                otherClientTread.join()
+                otherClientThread.join()
             }
         }
 
-        /**
-         * Checks if the [UpdateMentionsFromGitHub] command is rejected
-         * if the previous process is not completed.
-         *
-         * The execution of fetching mentions from [GitHubClientService] is frozen.
-         * Two threads are created that send the [UpdateMentionsFromGitHub] command.
-         * One of the threads successfully starts the update process,
-         * and another thread gets a rejection because the process has started.
-         * The thread whose command is rejected unfreezes the [GitHubClientService],
-         * which allows the update process to complete.
-         */
         @Test
         public fun `reject if the update process is already in progress at this time`() {
             gitHubClientService.freeze()
-            val firstClientTread = Thread {
+            val firstClientThread = Thread {
                 val firstCommand = UpdateMentionsFromGitHub::class.buildBy(gitHubClientId)
                 context().receivesCommand(firstCommand)
                 gitHubClientService.unfreeze()
@@ -177,9 +151,9 @@ public class GitHubClientSpec : ContextAwareTest() {
             val expectedRejection =
                 MentionsUpdateIsAlreadyInProgress::class.buildBy(gitHubClientId)
 
-            firstClientTread.start()
+            firstClientThread.start()
             secondClientThread.start()
-            firstClientTread.join()
+            firstClientThread.join()
             secondClientThread.join()
 
             context().assertEvent(expectedRejection)
@@ -216,7 +190,7 @@ public class GitHubClientSpec : ContextAwareTest() {
     }
 
     @Test
-    public fun `clear 'when_started' field after completing the updating process`() {
+    public fun `clear 'when_started' field after completing the update process`() {
         val command = UpdateMentionsFromGitHub::class.buildBy(gitHubClientId)
         context().receivesCommand(command)
         val expected = GitHubClient::class.buildBy(gitHubClientId, token)

--- a/mentions/src/test/kotlin/io/spine/examples/pingh/mentions/GitHubClientSpec.kt
+++ b/mentions/src/test/kotlin/io/spine/examples/pingh/mentions/GitHubClientSpec.kt
@@ -41,6 +41,7 @@ import io.spine.examples.pingh.mentions.given.buildWithDefaultWhenStartedField
 import io.spine.examples.pingh.mentions.given.expectedUserMentionedSet
 import io.spine.examples.pingh.mentions.rejection.GithubClientRejections.MentionsUpdateIsAlreadyInProgress
 import io.spine.examples.pingh.sessions.event.UserLoggedIn
+import io.spine.examples.pingh.sessions.newSessionsContext
 import io.spine.protobuf.AnyPacker
 import io.spine.server.BoundedContextBuilder
 import io.spine.testing.TestValues.randomString
@@ -61,12 +62,11 @@ public class GitHubClientSpec : ContextAwareTest() {
     private lateinit var token: PersonalAccessToken
 
     protected override fun contextBuilder(): BoundedContextBuilder =
-        newBuilder(gitHubClientService)
+        newMentionsContext(gitHubClientService)
 
     @BeforeEach
     public fun prepareSessionsContextAndEmitEvent() {
-        sessionContext = BlackBoxContext
-            .from(io.spine.examples.pingh.sessions.newBuilder())
+        sessionContext = BlackBoxContext.from(newSessionsContext())
         val username = Username::class.buildBy(randomString())
         gitHubClientId = GitHubClientId::class.buildBy(username)
         emitUserLoggedInEventInSessionsContext()

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/SessionsContext.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/SessionsContext.kt
@@ -37,6 +37,6 @@ public const val NAME: String = "Sessions"
 /**
  * Configures Sessions [BoundedContext] with repositories.
  */
-public fun newBuilder(): BoundedContextBuilder =
+public fun newSessionsContext(): BoundedContextBuilder =
     BoundedContext.singleTenant(NAME)
         .add(UserSessionProcess::class.java)

--- a/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/SessionsContextSpec.kt
+++ b/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/SessionsContextSpec.kt
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.Test
 public class SessionsContextSpec : ContextAwareTest() {
 
     protected override fun contextBuilder(): BoundedContextBuilder =
-        newBuilder()
+        newSessionsContext()
 
     @Nested
     public inner class `handle 'LogUserIn' command, and` {


### PR DESCRIPTION
This changeset improves code in the `mentions` module. 

Changes:
- Useless comments are removed from mention testing.
- Methods that create `BoundedContextBuilder`s are renamed. 
- Setting `archived` flag is removed from `GitHubClientProcess`.