### PR TITLE
Create message extensions in the `sessions` module

### DIFF
--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/CommandsExts.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/CommandsExts.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.pingh.mentions
+
+import com.google.protobuf.Timestamp
+import io.spine.base.Time.currentTime
+import io.spine.examples.pingh.mentions.command.MarkMentionAsRead
+import io.spine.examples.pingh.mentions.command.SnoozeMention
+import io.spine.examples.pingh.mentions.command.UpdateMentionsFromGitHub
+import kotlin.reflect.KClass
+
+/**
+ * Creates a new `MarkMentionAsRead` command with the specified ID of the mention.
+ */
+public fun KClass<MarkMentionAsRead>.buildBy(id: MentionId): MarkMentionAsRead =
+    MarkMentionAsRead.newBuilder()
+        .setId(id)
+        .vBuild()
+
+/**
+ * Creates a new `SnoozeMention` command with the specified ID of the mention and
+ * time to which the mention is snoozing.
+ */
+public fun KClass<SnoozeMention>.buildBy(id: MentionId, untilWhen: Timestamp): SnoozeMention =
+    SnoozeMention.newBuilder()
+        .setId(id)
+        .setUntilWhen(untilWhen)
+        .vBuild()
+
+/**
+ * Creates a new `UpdateMentionsFromGitHub` command with the specified `GitHubClientId`.
+ */
+public fun KClass<UpdateMentionsFromGitHub>.buildBy(id: GitHubClientId):
+        UpdateMentionsFromGitHub =
+    UpdateMentionsFromGitHub.newBuilder()
+        .setId(id)
+        .setWhenRequested(currentTime())
+        .vBuild()

--- a/mentions/src/test/kotlin/io/spine/examples/pingh/mentions/given/GitHubClientSpecEnv.kt
+++ b/mentions/src/test/kotlin/io/spine/examples/pingh/mentions/given/GitHubClientSpecEnv.kt
@@ -28,7 +28,6 @@ package io.spine.examples.pingh.mentions.given
 
 import com.google.protobuf.Timestamp
 import com.google.protobuf.util.Timestamps
-import io.spine.base.Time.currentTime
 import io.spine.examples.pingh.github.NodeId
 import io.spine.examples.pingh.github.PersonalAccessToken
 import io.spine.examples.pingh.github.User
@@ -38,17 +37,17 @@ import io.spine.examples.pingh.mentions.GitHubClient
 import io.spine.examples.pingh.mentions.GitHubClientId
 import io.spine.examples.pingh.mentions.MentionId
 import io.spine.examples.pingh.mentions.buildBy
-import io.spine.examples.pingh.mentions.command.UpdateMentionsFromGitHub
 import io.spine.examples.pingh.mentions.event.UserMentioned
 import io.spine.examples.pingh.mentions.parseIssuesAndPullRequestsFromJson
 import io.spine.examples.pingh.mentions.rejection.GithubClientRejections.MentionsUpdateIsAlreadyInProgress
 import io.spine.examples.pingh.sessions.SessionId
+import io.spine.examples.pingh.sessions.buildBy
 import io.spine.examples.pingh.sessions.event.UserLoggedIn
 import io.spine.net.Url
 import kotlin.reflect.KClass
 
 /**
- * Creates a new [GitHubClient] with the specified [GitHubClientId] and [PersonalAccessToken].
+ * Creates a new `GitHubClient` with the specified `GitHubClientId` and `PersonalAccessToken`.
  */
 internal fun KClass<GitHubClient>.buildBy(id: GitHubClientId, token: PersonalAccessToken):
         GitHubClient =
@@ -58,7 +57,7 @@ internal fun KClass<GitHubClient>.buildBy(id: GitHubClientId, token: PersonalAcc
         .vBuild()
 
 /**
- * Creates a new [GitHubClient] with the `when_started` field filled with the default value.
+ * Creates a new `GitHubClient` with the `when_started` field filled with the default value.
  */
 internal fun KClass<GitHubClient>.buildWithDefaultWhenStartedField(): GitHubClient =
     GitHubClient.newBuilder()
@@ -68,32 +67,17 @@ internal fun KClass<GitHubClient>.buildWithDefaultWhenStartedField(): GitHubClie
         .buildPartial()
 
 /**
- * Creates a new [UpdateMentionsFromGitHub] command with the specified [GitHubClientId].
- */
-internal fun KClass<UpdateMentionsFromGitHub>.buildBy(id: GitHubClientId):
-        UpdateMentionsFromGitHub =
-    UpdateMentionsFromGitHub.newBuilder()
-        .setId(id)
-        .setWhenRequested(currentTime())
-        .vBuild()
-
-/**
- * Creates a new [UserLoggedIn] event with the specified [Username] and [PersonalAccessToken].
+ * Creates a new `UserLoggedIn` event with the specified `Username` and `PersonalAccessToken`.
  */
 internal fun KClass<UserLoggedIn>.buildBy(username: Username, token: PersonalAccessToken):
         UserLoggedIn =
-    UserLoggedIn.newBuilder()
-        .setId(
-            SessionId.newBuilder()
-                .setUsername(username)
-                .setWhenCreated(currentTime())
-                .vBuild()
-        )
-        .setToken(token)
-        .vBuild()
+    this.buildBy(
+        SessionId::class.buildBy(username),
+        token
+    )
 
 /**
- * Creates a new [MentionsUpdateIsAlreadyInProgress] rejection with the specified [GitHubClientId].
+ * Creates a new `MentionsUpdateIsAlreadyInProgress` rejection with the specified `GitHubClientId`.
  */
 internal fun KClass<MentionsUpdateIsAlreadyInProgress>.buildBy(id: GitHubClientId):
         MentionsUpdateIsAlreadyInProgress =
@@ -102,7 +86,7 @@ internal fun KClass<MentionsUpdateIsAlreadyInProgress>.buildBy(id: GitHubClientI
         .vBuild()
 
 /**
- * Reads mention data from a prepared JSON, converts it to [UserMentioned] events,
+ * Reads mention data from a prepared JSON, converts it to `UserMentioned` events,
  * and returns their set.
  */
 internal fun expectedUserMentionedSet(whoWasMentioned: Username): Set<UserMentioned> {

--- a/mentions/src/test/kotlin/io/spine/examples/pingh/mentions/given/MentionSpecEnv.kt
+++ b/mentions/src/test/kotlin/io/spine/examples/pingh/mentions/given/MentionSpecEnv.kt
@@ -26,7 +26,6 @@
 
 package io.spine.examples.pingh.mentions.given
 
-import com.google.protobuf.Timestamp
 import io.spine.base.Time.currentTime
 import io.spine.examples.pingh.github.NodeId
 import io.spine.examples.pingh.github.User
@@ -36,8 +35,6 @@ import io.spine.examples.pingh.mentions.Mention
 import io.spine.examples.pingh.mentions.MentionId
 import io.spine.examples.pingh.mentions.MentionStatus
 import io.spine.examples.pingh.mentions.buildBy
-import io.spine.examples.pingh.mentions.command.MarkMentionAsRead
-import io.spine.examples.pingh.mentions.command.SnoozeMention
 import io.spine.examples.pingh.mentions.event.MentionSnoozed
 import io.spine.examples.pingh.mentions.event.UserMentioned
 import io.spine.examples.pingh.mentions.rejection.Rejections.MentionIsAlreadyRead
@@ -74,24 +71,6 @@ internal fun KClass<Mention>.buildBy(id: MentionId, status: MentionStatus): Ment
     Mention.newBuilder()
         .setId(id)
         .setStatus(status)
-        .vBuild()
-
-/**
- * Creates a new `MarkMentionAsRead` command with the specified ID of the mention.
- */
-internal fun KClass<MarkMentionAsRead>.buildBy(id: MentionId): MarkMentionAsRead =
-    MarkMentionAsRead.newBuilder()
-        .setId(id)
-        .vBuild()
-
-/**
- * Creates a new `SnoozeMention` command with the specified ID of the mention and
- * time to which the mention is snoozing.
- */
-internal fun KClass<SnoozeMention>.buildBy(id: MentionId, untilWhen: Timestamp): SnoozeMention =
-    SnoozeMention.newBuilder()
-        .setId(id)
-        .setUntilWhen(untilWhen)
         .vBuild()
 
 /**

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/CommandsExts.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/CommandsExts.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.pingh.sessions
+
+import io.spine.examples.pingh.sessions.command.LogUserIn
+import io.spine.examples.pingh.sessions.command.LogUserOut
+import kotlin.reflect.KClass
+
+/**
+ * Creates a new `LogUserIn` command with the specified ID of the session.
+ */
+public fun KClass<LogUserIn>.buildBy(id: SessionId): LogUserIn =
+    LogUserIn.newBuilder()
+        .setId(id)
+        .vBuild()
+
+/**
+ * Creates a new `LogUserOut` command with the specified ID of the session.
+ */
+public fun KClass<LogUserOut>.buildBy(id: SessionId): LogUserOut =
+    LogUserOut.newBuilder()
+        .setId(id)
+        .vBuild()

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/EventsExts.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/EventsExts.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.pingh.sessions
+
+import io.spine.examples.pingh.github.PersonalAccessToken
+import io.spine.examples.pingh.sessions.event.UserLoggedIn
+import io.spine.examples.pingh.sessions.event.UserLoggedOut
+import kotlin.reflect.KClass
+
+/**
+ * Creates a new `UserLoggedIn` event with the specified ID of the session
+ * and `PersonalAccessToken`.
+ */
+public fun KClass<UserLoggedIn>.buildBy(id: SessionId, token: PersonalAccessToken): UserLoggedIn =
+    UserLoggedIn.newBuilder()
+        .setId(id)
+        .setToken(token)
+        .vBuild()
+
+/**
+ * Creates a new `UserLoggedOut` event with the specified ID of the session.
+ */
+public fun KClass<UserLoggedOut>.buildBy(id: SessionId): UserLoggedOut =
+    UserLoggedOut.newBuilder()
+        .setId(id)
+        .vBuild()

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/IdentifiersExts.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/IdentifiersExts.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.pingh.sessions
+
+import com.google.protobuf.Timestamp
+import io.spine.base.Time.currentTime
+import io.spine.examples.pingh.github.Username
+import kotlin.reflect.KClass
+
+/**
+ * Creates a new `SessionId` with the specified name of the user to which the session belongs.
+ * The time of the session creation is the current time.
+ */
+public fun KClass<SessionId>.buildBy(username: Username): SessionId =
+    this.buildBy(username, currentTime())
+
+/**
+ * Creates a new `SessionId` with the specified name of the user to which the session belongs
+ * and the time when the session is created.
+ */
+public fun KClass<SessionId>.buildBy(username: Username, whenCreated: Timestamp): SessionId =
+    SessionId.newBuilder()
+        .setUsername(username)
+        .setWhenCreated(whenCreated)
+        .vBuild()

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/UserSessionProcess.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/UserSessionProcess.kt
@@ -27,6 +27,7 @@
 package io.spine.examples.pingh.sessions
 
 import io.spine.examples.pingh.github.PersonalAccessToken
+import io.spine.examples.pingh.github.buildBy
 import io.spine.examples.pingh.sessions.command.LogUserIn
 import io.spine.examples.pingh.sessions.command.LogUserOut
 import io.spine.examples.pingh.sessions.event.UserLoggedIn
@@ -46,14 +47,10 @@ public class UserSessionProcess :
     @Assign
     internal fun handle(command: LogUserIn): UserLoggedIn {
         initState(command)
-        return with(UserLoggedIn.newBuilder()) {
-            id = command.id
-            token = with(PersonalAccessToken.newBuilder()) {
-                value = "token"
-                vBuild()
-            }
-            vBuild()
-        }
+        return UserLoggedIn::class.buildBy(
+            command.id,
+            PersonalAccessToken::class.buildBy("token")
+        )
     }
 
     private fun initState(command: LogUserIn) {
@@ -66,9 +63,6 @@ public class UserSessionProcess :
     @Assign
     internal fun handle(command: LogUserOut): UserLoggedOut {
         deleted = true
-        return with(UserLoggedOut.newBuilder()) {
-            id = command.id
-            vBuild()
-        }
+        return UserLoggedOut::class.buildBy(command.id)
     }
 }

--- a/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/given/SessionsContextSpecEnv.kt
+++ b/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/given/SessionsContextSpecEnv.kt
@@ -26,62 +26,37 @@
 
 package io.spine.examples.pingh.sessions.given
 
-import io.spine.base.Time.currentTime
 import io.spine.examples.pingh.github.Username
+import io.spine.examples.pingh.github.buildBy
 import io.spine.examples.pingh.sessions.SessionId
 import io.spine.examples.pingh.sessions.UserSession
-import io.spine.examples.pingh.sessions.command.LogUserIn
-import io.spine.examples.pingh.sessions.command.LogUserOut
+import io.spine.examples.pingh.sessions.buildBy
+import io.spine.examples.pingh.sessions.event.UserLoggedIn
 import io.spine.testing.TestValues.randomString
+import kotlin.reflect.KClass
 
 /**
- * Returns the identifier for the session.
- *
- * The creator's [Username] is selected randomly,
- * and the creation time is set at the current moment.
+ * Creates a new `SessionId` with a randomly generated `Username`
+ * and creation time specified as now.
  */
-public fun sessionId(): SessionId =
-    sessionIdBy(
-        with(Username.newBuilder()) {
-            value = randomString()
-            vBuild()
-        })
+internal fun KClass<SessionId>.generate(): SessionId =
+    this.buildBy(Username::class.buildBy(randomString()))
 
 /**
- * Returns the identifier for the session based on the passed [Username].
- *
- * The creation time is indicated at the current moment.
+ * Creates a new `UserSession` with the specified ID of the session.
  */
-public fun sessionIdBy(name: Username): SessionId =
-    with(SessionId.newBuilder()) {
-        username = name
-        whenCreated = currentTime()
-        vBuild()
-    }
+internal fun KClass<UserSession>.buildBy(id: SessionId): UserSession =
+    UserSession.newBuilder()
+        .setId(id)
+        .vBuild()
 
 /**
- * Returns the [UserSession] process manager, created using the passed [SessionId].
+ * Creates a new `UserLoggedIn` event with the specified ID of the session
+ * and the unspecified token.
  */
-public fun userSession(session: SessionId): UserSession =
-    with(UserSession.newBuilder()) {
-        id = session
-        vBuild()
-    }
-
-/**
- * Returns the [LogUserIn] command, created using the passed [SessionId].
- */
-public fun logUserIn(sessionId: SessionId): LogUserIn =
-    with(LogUserIn.newBuilder()) {
-        id = sessionId
-        vBuild()
-    }
-
-/**
- * Returns the [LogUserOut] command, created using the passed [SessionId].
- */
-public fun logUserOut(sessionId: SessionId): LogUserOut =
-    with(LogUserOut.newBuilder()) {
-        id = sessionId
-        vBuild()
-    }
+internal fun KClass<UserLoggedIn>.buildWithoutToken(id: SessionId): UserLoggedIn =
+    UserLoggedIn.newBuilder()
+        .setId(id)
+        // Building the message partially to include
+        // only the tested fields.
+        .buildPartial()


### PR DESCRIPTION
This changeset adds and uses message creation extensions in the `sessions` module. Also, extensions for creating commands in the `sessions` and `mentions` modules are moved to the main code from the tests, for further use on the client side.