### PR TITLE
Bump gPRC from 1.47.0 to 1.58.0

### DIFF
--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import io.spine.internal.dependency.Grpc
+import io.spine.internal.dependency.Guava
+import org.gradle.api.artifacts.ConfigurationContainer
+
+/**
+ * Forces dependencies for gRPC operation in the project.
+ *
+ * Also forces necessary transitive dependencies.
+ */
+public fun forceGrpcDependencies(configurations: ConfigurationContainer) {
+    configurations.all {
+        resolutionStrategy {
+            force(
+                Guava.lib,
+                Grpc.netty,
+                Grpc.inprocess
+            )
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
@@ -29,6 +29,7 @@ package io.spine.internal.dependency
 // https://github.com/grpc/grpc-java
 @Suppress("ConstPropertyName")
 public object Grpc {
-    private const val version = "1.47.0"
+    private const val version = "1.58.0"
     public const val netty: String = "io.grpc:grpc-netty:$version"
+    public const val inprocess: String = "io.grpc:grpc-inprocess:$version"
 }

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -44,6 +44,8 @@ spine {
     enableJava().client()
 }
 
+forceGrpcDependencies(configurations)
+
 kotlin {
     jvmToolchain {
         languageVersion.set(BuildSettings.javaVersion)
@@ -56,6 +58,7 @@ dependencies {
     implementation(JavaX.annotations)
     implementation(Guava.lib)
     implementation(Grpc.netty)
+    implementation(Grpc.inprocess)
 
     testImplementation(project(":testutil-mentions"))
     testImplementation(Spine.Server.lib)

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -40,6 +40,8 @@ plugins {
     application
 }
 
+forceGrpcDependencies(configurations)
+
 spine {
     // Add and configure required dependencies for developing a Spine-based Java server.
     // See: https://github.com/SpineEventEngine/bootstrap#java-projects
@@ -63,6 +65,7 @@ dependencies {
     implementation(Ktor.Client.cio)
     implementation(Guava.lib)
     implementation(Grpc.netty)
+    implementation(Grpc.inprocess)
 }
 
 application {


### PR DESCRIPTION
This changeset bumps gPRC from 1.47.0 to 1.58.0 and forces the necessary dependencies for the new gRPC version.