### PR TITLE
Implement end-to-end tests to check client-server interactions

### DIFF
--- a/client/src/main/kotlin/io/spine/examples/pingh/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/DesktopClient.kt
@@ -26,6 +26,7 @@
 
 package io.spine.examples.pingh.client
 
+import com.google.protobuf.Duration
 import com.google.protobuf.Message
 import io.grpc.ManagedChannelBuilder
 import io.spine.base.CommandMessage
@@ -59,6 +60,7 @@ import io.spine.examples.pingh.sessions.command.LogUserIn
 import io.spine.examples.pingh.sessions.command.LogUserOut
 import io.spine.examples.pingh.sessions.event.UserLoggedIn
 import io.spine.examples.pingh.sessions.event.UserLoggedOut
+import io.spine.protobuf.Durations2
 import java.util.UUID
 import kotlin.reflect.KClass
 
@@ -72,8 +74,15 @@ import kotlin.reflect.KClass
 // to interact with the server, which does not enable Detekt.
 public class DesktopClient(
     address: String = "localhost",
-    port: Int = DEFAULT_CLIENT_SERVICE_PORT,
+    port: Int = DEFAULT_CLIENT_SERVICE_PORT
 ) {
+
+    private companion object {
+        /**
+         * The default snooze time of mention.
+         */
+        private val defaultSnoozeTime = Durations2.hours(2)
+    }
 
     private val client: Client
     private val user: UserId
@@ -167,10 +176,16 @@ public class DesktopClient(
     }
 
     /**
-     * Marks the mention as a 2-hour snooze.
+     * Marks the mention as snoozed.
+     *
+     * If snooze time is not specified, the mention will snooze the `defaultSnoozeTime`.
      */
-    public fun snoozeMention(id: MentionId, onSuccess: (event: MentionSnoozed) -> Unit = {}) {
-        val command = SnoozeMention::class.buildBy(id, currentTime().inTwoHours())
+    public fun snoozeMention(
+        id: MentionId,
+        snoozeTime: Duration = defaultSnoozeTime,
+        onSuccess: (event: MentionSnoozed) -> Unit = {}
+    ) {
+        val command = SnoozeMention::class.buildBy(id, currentTime().add(snoozeTime))
         observeEventOnce(command.id, MentionSnoozed::class, onSuccess)
         send(command)
     }

--- a/client/src/main/kotlin/io/spine/examples/pingh/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/DesktopClient.kt
@@ -128,8 +128,6 @@ public class DesktopClient(
         val command = LogUserOut::class.buildBy(session!!)
         observeEventOnce(command.id, UserLoggedOut::class) { event ->
             this.session = null
-            client.subscriptions()
-                .cancelAll()
             onSuccess(event)
         }
         send(command)

--- a/client/src/main/kotlin/io/spine/examples/pingh/client/DesktopClient.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/DesktopClient.kt
@@ -176,7 +176,7 @@ public class DesktopClient(
     /**
      * Marks the mention as snoozed.
      *
-     * If snooze time is not specified, the mention will snooze the `defaultSnoozeTime`.
+     * If snooze time is not specified, the mention will snooze the [defaultSnoozeTime].
      */
     public fun snoozeMention(
         id: MentionId,

--- a/client/src/main/kotlin/io/spine/examples/pingh/client/TimestampExts.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/TimestampExts.kt
@@ -27,11 +27,10 @@
 package io.spine.examples.pingh.client
 
 import com.google.protobuf.Timestamp
-import com.google.protobuf.util.Durations
+import com.google.protobuf.Duration
 import com.google.protobuf.util.Timestamps
 
 /**
- * Sets the time 2 hours from this time.
+ * Adds a duration to this timestamp.
  */
-public fun Timestamp.inTwoHours(): Timestamp =
-    Timestamps.add(this, Durations.fromHours(2))
+public fun Timestamp.add(duration: Duration): Timestamp = Timestamps.add(this, duration)

--- a/client/src/test/kotlin/io/spine/examples/pingh/client/e2e/PersonalInteractionTest.kt
+++ b/client/src/test/kotlin/io/spine/examples/pingh/client/e2e/PersonalInteractionTest.kt
@@ -33,6 +33,8 @@ import io.spine.examples.pingh.client.e2e.given.updateStatusById
 import io.spine.examples.pingh.github.Username
 import io.spine.examples.pingh.github.buildBy
 import io.spine.examples.pingh.mentions.MentionStatus
+import io.spine.protobuf.Durations2.milliseconds
+import java.lang.Thread.sleep
 import org.junit.jupiter.api.Test
 
 /**
@@ -65,6 +67,40 @@ public class PersonalInteractionTest : IntegrationTest() {
         client().readMention(changedMention.id)
         actual = client().findUserMentions()
         expected = expected.updateStatusById(changedMention.id, MentionStatus.READ)
+        actual shouldBe expected
+    }
+
+    @Test
+    public fun `the user should snooze the mention and wait until the snooze period is over`() {
+        val username = Username::class.buildBy("MykytaPimonovTD")
+        client().logIn(username)
+
+        client().updateMentions()
+        var actual = client().findUserMentions()
+        var expected = expectedMentionsList(username)
+        actual shouldBe expected
+
+        var changedMention = actual.randomUnread()
+        client().readMention(changedMention.id)
+        actual = client().findUserMentions()
+        expected = expected.updateStatusById(changedMention.id, MentionStatus.READ)
+        actual shouldBe expected
+
+        changedMention = actual.randomUnread()
+        client().readMention(changedMention.id)
+        actual = client().findUserMentions()
+        expected = expected.updateStatusById(changedMention.id, MentionStatus.READ)
+        actual shouldBe expected
+
+        changedMention = actual.randomUnread()
+        client().snoozeMention(changedMention.id, milliseconds(100))
+        actual = client().findUserMentions()
+        expected = expected.updateStatusById(changedMention.id, MentionStatus.SNOOZED)
+        actual shouldBe expected
+
+        sleep(300)
+        actual = client().findUserMentions()
+        expected = expected.updateStatusById(changedMention.id, MentionStatus.UNREAD)
         actual shouldBe expected
     }
 }

--- a/client/src/test/kotlin/io/spine/examples/pingh/client/e2e/PersonalInteractionTest.kt
+++ b/client/src/test/kotlin/io/spine/examples/pingh/client/e2e/PersonalInteractionTest.kt
@@ -44,16 +44,16 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 /**
- * End-to-end test that checks client-server interaction.
+ * End-to-end test to checks client-server interaction.
  */
 public class PersonalInteractionTest : IntegrationTest() {
 
     private val username = Username::class.buildBy("MykytaPimonovTD")
-    private var actual: List<MentionView> = listOf()
-    private var expected: List<MentionView> = listOf()
+    private lateinit var actual: List<MentionView>
+    private lateinit var expected: List<MentionView>
 
     @BeforeEach
-    public fun logInAndLoadMentions() {
+    public fun logInAndUpdateMentions() {
         client().logIn(username)
         client().updateMentions()
         actual = client().findUserMentions()

--- a/client/src/test/kotlin/io/spine/examples/pingh/client/e2e/PersonalInteractionTest.kt
+++ b/client/src/test/kotlin/io/spine/examples/pingh/client/e2e/PersonalInteractionTest.kt
@@ -45,13 +45,6 @@ import org.junit.jupiter.api.Test
 
 /**
  * End-to-end test to checks client-server interaction.
- *
- * Each test checks a different use case. Any of the tests can be described as a scenario:
- *
- * 1. The user logs in to the Pingh app.
- * 2. The user updates their mentions from GitHub.
- *
- * Next steps of the scenario vary across different tests.
  */
 public class PersonalInteractionTest : IntegrationTest() {
 
@@ -69,8 +62,14 @@ public class PersonalInteractionTest : IntegrationTest() {
     }
 
     /**
-     * 3. The user snoozes a random mention
-     * 4. The user reads the snoozed mention.
+     * End-to-end test that describes such a scenario:
+     *
+     * The user:
+     *
+     * 1. Logs in to the Pingh app.
+     * 2. Updates their mentions from GitHub.
+     * 3. Snoozes a random mention
+     * 4. Reads the snoozed mention.
      */
     @Test
     public fun `the user should snooze the mention, and then read this mention`() {
@@ -83,9 +82,15 @@ public class PersonalInteractionTest : IntegrationTest() {
     }
 
     /**
-     * 3. The user snoozes a random mention for 100 milliseconds.
-     * 4. The user waits until the snooze time is over.
-     * 5. The user checks that the snoozed mention is already unsnoozed.
+     * End-to-end test that describes such a scenario:
+     *
+     * The user:
+     *
+     * 1. Logs in to the Pingh app.
+     * 2. Updates their mentions from GitHub.
+     * 3. Snoozes a random mention for 100 milliseconds.
+     * 4. Waits until the snooze time is over.
+     * 5. Checks that the snoozed mention is already unsnoozed.
      */
     @Test
     public fun `the user should snooze the mention and wait until the snooze time is over`() {
@@ -98,10 +103,16 @@ public class PersonalInteractionTest : IntegrationTest() {
     }
 
     /**
-     * 3. The user logs out of the Pingh app.
-     * 4. The user tries to get mentions but catches the exception.
-     * 5. The user logs in again.
-     * 6. The user gets mentions that were updated in the first session.
+     * End-to-end test that describes such a scenario:
+     *
+     * The user:
+     *
+     * 1. Logs in to the Pingh app.
+     * 2. Updates their mentions from GitHub.
+     * 3. Logs out of the Pingh app.
+     * 4. Tries to get mentions but catches the exception.
+     * 5. Logs in again.
+     * 6. Gets mentions that were updated in the first session.
      */
     @Test
     public fun `the user should log in, log out, log in again, and then gets mentions`() {

--- a/client/src/test/kotlin/io/spine/examples/pingh/client/e2e/PersonalInteractionTest.kt
+++ b/client/src/test/kotlin/io/spine/examples/pingh/client/e2e/PersonalInteractionTest.kt
@@ -28,6 +28,7 @@ package io.spine.examples.pingh.client.e2e
 
 import io.kotest.matchers.shouldBe
 import io.spine.examples.pingh.client.e2e.given.expectedMentionsList
+import io.spine.examples.pingh.client.e2e.given.randomUnread
 import io.spine.examples.pingh.client.e2e.given.updateStatusById
 import io.spine.examples.pingh.github.Username
 import io.spine.examples.pingh.github.buildBy
@@ -54,13 +55,13 @@ public class PersonalInteractionTest : IntegrationTest() {
         var expected = expectedMentionsList(username)
         actual shouldBe expected
 
-        var changedMention = actual.random()
+        var changedMention = actual.randomUnread()
         client().snoozeMention(changedMention.id)
         actual = client().findUserMentions()
         expected = expected.updateStatusById(changedMention.id, MentionStatus.SNOOZED)
         actual shouldBe expected
 
-        changedMention = actual.random()
+        changedMention = actual.randomUnread()
         client().readMention(changedMention.id)
         actual = client().findUserMentions()
         expected = expected.updateStatusById(changedMention.id, MentionStatus.READ)

--- a/client/src/test/kotlin/io/spine/examples/pingh/client/e2e/PersonalInteractionTest.kt
+++ b/client/src/test/kotlin/io/spine/examples/pingh/client/e2e/PersonalInteractionTest.kt
@@ -112,7 +112,7 @@ public class PersonalInteractionTest : IntegrationTest() {
      * 3. Logs out of the Pingh app.
      * 4. Tries to get mentions but catches the exception.
      * 5. Logs in again.
-     * 6. Gets mentions that were updated in the first session.
+     * 6. Reads mentions that were updated in the first session.
      */
     @Test
     public fun `the user should log in, log out, log in again, and then gets mentions`() {

--- a/client/src/test/kotlin/io/spine/examples/pingh/client/e2e/given/PersonalInteractionTestEnv.kt
+++ b/client/src/test/kotlin/io/spine/examples/pingh/client/e2e/given/PersonalInteractionTestEnv.kt
@@ -66,3 +66,10 @@ internal fun List<MentionView>.updateStatusById(id: MentionId, status: MentionSt
             .setStatus(status)
             .vBuild()
     }
+
+/**
+ * Returns a random `MentionView` with `UNREAD` status from this list.
+ */
+internal fun List<MentionView>.randomUnread(): MentionView =
+    this.filter { it.status == MentionStatus.UNREAD }
+        .random()

--- a/client/src/test/kotlin/io/spine/examples/pingh/client/e2e/given/PersonalInteractionTestEnv.kt
+++ b/client/src/test/kotlin/io/spine/examples/pingh/client/e2e/given/PersonalInteractionTestEnv.kt
@@ -69,6 +69,9 @@ internal fun List<MentionView>.updateStatusById(id: MentionId, status: MentionSt
 
 /**
  * Returns a random `MentionView` with `UNREAD` status from this list.
+ *
+ * @throws NoSuchElementException if this list has no unread mentions.
+ * @see [Collection.random]
  */
 internal fun List<MentionView>.randomUnread(): MentionView =
     this.filter { it.status == MentionStatus.UNREAD }

--- a/testutil-mentions/src/main/kotlin/io/spine/examples/pingh/testing/mentions/given/PredefinedGitHubResponses.kt
+++ b/testutil-mentions/src/main/kotlin/io/spine/examples/pingh/testing/mentions/given/PredefinedGitHubResponses.kt
@@ -31,11 +31,9 @@ import io.ktor.http.HttpStatusCode
 import io.spine.examples.pingh.github.Mention
 import io.spine.examples.pingh.github.PersonalAccessToken
 import io.spine.examples.pingh.github.Username
-import io.spine.examples.pingh.github.buildFromFragment
 import io.spine.examples.pingh.mentions.GitHubClient
 import io.spine.examples.pingh.mentions.GitHubClientService
 import io.spine.examples.pingh.mentions.CannotFetchMentionsFromGitHubException
-import io.spine.examples.pingh.mentions.parseIssuesAndPullRequestsFromJson
 import java.lang.Thread.sleep
 import kotlin.jvm.Throws
 
@@ -82,13 +80,7 @@ public class PredefinedGitHubResponses : GitHubClientService {
         if (responseStatusCode != HttpStatusCode.OK) {
             throw CannotFetchMentionsFromGitHubException(responseStatusCode.value)
         }
-        val jsonFile = this::class.java.getResource("/github-responses/prs-search-response.json")
-        checkNotNull(jsonFile)
-        val json = jsonFile.readText(Charsets.UTF_8)
-        val mentions = parseIssuesAndPullRequestsFromJson(json)
-            .itemList
-            .map { fragment -> Mention::class.buildFromFragment(fragment) }
-            .toSet()
+        val mentions = predefinedMentionsSet()
         waitWhileServiceIsFrozen()
         return mentions
     }

--- a/testutil-mentions/src/main/kotlin/io/spine/examples/pingh/testing/mentions/given/PredefinedMentionsSet.kt
+++ b/testutil-mentions/src/main/kotlin/io/spine/examples/pingh/testing/mentions/given/PredefinedMentionsSet.kt
@@ -28,12 +28,19 @@ package io.spine.examples.pingh.testing.mentions.given
 
 import io.spine.examples.pingh.github.Mention
 import io.spine.examples.pingh.github.buildFromFragment
+import io.spine.examples.pingh.mentions.parseCommentsFromJson
 import io.spine.examples.pingh.mentions.parseIssuesAndPullRequestsFromJson
 
 /**
  * Returns the set of mentions that [PredefinedGitHubResponses] returns on successful execution.
  */
-public fun predefinedMentionsSet(): Set<Mention> {
+public fun predefinedMentionsSet(): Set<Mention> =
+    loadMentionsInPr() + loadMentionsInCommentsUnderPr()
+
+/**
+ * Loads mentions from the prepared JSON response to a mention search request in pull requests.
+ */
+private fun loadMentionsInPr(): Set<Mention> {
     val jsonFile = PredefinedGitHubResponses::class.java
         .getResource("/github-responses/prs-search-response.json")
     checkNotNull(jsonFile)
@@ -41,5 +48,22 @@ public fun predefinedMentionsSet(): Set<Mention> {
     return parseIssuesAndPullRequestsFromJson(json)
         .itemList
         .map { fragment -> Mention::class.buildFromFragment(fragment) }
+        .toSet()
+}
+
+/**
+ * Loads mentions from the prepared JSON response to a comments obtain request under pull request.
+ */
+private fun loadMentionsInCommentsUnderPr(): Set<Mention> {
+    val jsonFile = PredefinedGitHubResponses::class.java
+        .getResource("/github-responses/comments-under-pr-response.json")
+    checkNotNull(jsonFile)
+    val json = jsonFile.readText(Charsets.UTF_8)
+    // The received JSON contains only an array, but Protobuf JSON Parser
+    // cannot process it. So the array is converted to JSON, where the result
+    // is just the value of the `item` field.
+    return parseCommentsFromJson("{ item: $json }")
+        .itemList
+        .map { fragment -> Mention::class.buildFromFragment(fragment, "Comment") }
         .toSet()
 }

--- a/testutil-mentions/src/main/kotlin/io/spine/examples/pingh/testing/mentions/given/PredefinedMentionsSet.kt
+++ b/testutil-mentions/src/main/kotlin/io/spine/examples/pingh/testing/mentions/given/PredefinedMentionsSet.kt
@@ -38,7 +38,10 @@ public fun predefinedMentionsSet(): Set<Mention> =
     loadMentionsInPr() + loadMentionsInCommentsUnderPr()
 
 /**
- * Loads mentions from the prepared JSON response to a mention search request in pull requests.
+ * Loads mentions from the predefined JSON file.
+ *
+ * The predefined response loaded corresponds to the exact response
+ * returned by the GitHub API when requesting for mentions in a pull request.
  */
 private fun loadMentionsInPr(): Set<Mention> {
     val jsonFile = PredefinedGitHubResponses::class.java
@@ -52,7 +55,10 @@ private fun loadMentionsInPr(): Set<Mention> {
 }
 
 /**
- * Loads mentions from the prepared JSON response to a comments obtain request under pull request.
+ * Loads mentions from the predefined JSON file.
+ *
+ * The predefined response loaded corresponds to the exact response
+ * returned by the GitHub API when requesting for mentions in comments under a pull request.
  */
 private fun loadMentionsInCommentsUnderPr(): Set<Mention> {
     val jsonFile = PredefinedGitHubResponses::class.java


### PR DESCRIPTION
This changeset implements end-to-end tests to check client-server interactions.

Changes:
- Adds the ability to specify snooze time in the `DesktopClient`.
- Increases the number of returned mentions in the `PredefinedGitHubResponses`.
- Tests several use cases.