### PR TITLE
Refresh tokens automatically

### DIFF
--- a/github/src/main/kotlin/io/spine/examples/pingh/github/ValuesExts.kt
+++ b/github/src/main/kotlin/io/spine/examples/pingh/github/ValuesExts.kt
@@ -183,3 +183,11 @@ public fun KClass<AccessTokenResponse>.fromFragment(
         refreshToken = RefreshToken::class.of(fragment.refreshToken)
         vBuild()
     }
+
+/**
+ * Creates a new `ClientSecret` with the specified string value.
+ */
+public fun KClass<ClientSecret>.of(value: String): ClientSecret =
+    ClientSecret.newBuilder()
+        .setValue(value)
+        .vBuild()

--- a/github/src/main/proto/spine_examples/pingh/github/values.proto
+++ b/github/src/main/proto/spine_examples/pingh/github/values.proto
@@ -111,3 +111,13 @@ message RefreshToken {
     // A valid GitHub refresh token starts with 'ghr_'.
     string value = 1 [(required) = true, (pattern).regex = "^ghr_.+$"];
 }
+
+// The client secret of a GitHub App.
+//
+// This secret is created and issued by GitHub when a GitHub App is set up.
+// The client secret is used in the authentication flow to refresh access tokens.
+//
+message ClientSecret {
+
+    string value = 1 [(required) = true];
+}

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubClientProcess.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubClientProcess.kt
@@ -43,6 +43,7 @@ import io.spine.examples.pingh.mentions.event.MentionsUpdateFromGitHubRequested
 import io.spine.examples.pingh.mentions.event.RequestMentionsFromGitHubFailed
 import io.spine.examples.pingh.mentions.event.UserMentioned
 import io.spine.examples.pingh.mentions.rejection.MentionsUpdateIsAlreadyInProgress
+import io.spine.examples.pingh.sessions.event.TokenRefreshed
 import io.spine.examples.pingh.sessions.event.UserLoggedIn
 import io.spine.protobuf.Durations2.minutes
 import io.spine.protobuf.Durations2.toNanos
@@ -83,6 +84,18 @@ internal class GitHubClientProcess :
      */
     @React
     internal fun on(@External event: UserLoggedIn): GitHubTokenUpdated {
+        builder().setToken(event.token)
+        return GitHubTokenUpdated::class.buildBy(
+            GitHubClientId::class.of(event.id.username),
+            event.token
+        )
+    }
+
+    /**
+     * Updates the user's [PersonalAccessToken] each time it is refreshed.
+     */
+    @React
+    internal fun on(@External event: TokenRefreshed): GitHubTokenUpdated {
         builder().setToken(event.token)
         return GitHubTokenUpdated::class.buildBy(
             GitHubClientId::class.of(event.id.username),

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubClientRepository.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubClientRepository.kt
@@ -29,6 +29,7 @@ package io.spine.examples.pingh.mentions
 import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper
 import io.spine.examples.pingh.clock.event.TimePassed
 import io.spine.examples.pingh.sessions.SessionId
+import io.spine.examples.pingh.sessions.event.TokenRefreshed
 import io.spine.examples.pingh.sessions.event.UserLoggedIn
 import io.spine.server.procman.ProcessManagerRepository
 import io.spine.server.route.EventRouting
@@ -45,6 +46,9 @@ internal class GitHubClientRepository(
         super.setupEventRouting(routing)
         routing
             .route(UserLoggedIn::class.java) { event, _ ->
+                toGitHubClientId(event.id)
+            }
+            .route(TokenRefreshed::class.java) { event, _ ->
                 toGitHubClientId(event.id)
             }
             .route(TimePassed::class.java) { _, _ -> toAll() }

--- a/mentions/src/test/kotlin/io/spine/examples/pingh/mentions/GitHubClientSpec.kt
+++ b/mentions/src/test/kotlin/io/spine/examples/pingh/mentions/GitHubClientSpec.kt
@@ -47,8 +47,13 @@ import io.spine.examples.pingh.mentions.given.buildWithDefaultWhenStartedField
 import io.spine.examples.pingh.mentions.given.expectedUserMentionedSet
 import io.spine.examples.pingh.mentions.given.generate
 import io.spine.examples.pingh.mentions.rejection.GithubClientRejections.MentionsUpdateIsAlreadyInProgress
+import io.spine.examples.pingh.sessions.SessionId
+import io.spine.examples.pingh.sessions.buildBy
+import io.spine.examples.pingh.sessions.event.TokenRefreshed
 import io.spine.examples.pingh.sessions.event.UserLoggedIn
 import io.spine.examples.pingh.sessions.newSessionsContext
+import io.spine.examples.pingh.sessions.of
+import io.spine.examples.pingh.sessions.with
 import io.spine.examples.pingh.testing.mentions.given.PredefinedGitHubSearchResponses
 import io.spine.examples.pingh.testing.sessions.given.PredefinedGitHubAuthenticationResponses
 import io.spine.protobuf.Durations2.seconds
@@ -69,6 +74,7 @@ internal class GitHubClientSpec : ContextAwareTest() {
     private val gitHubClientService = PredefinedGitHubSearchResponses()
     private lateinit var sessionContext: BlackBoxContext
     private lateinit var gitHubClientId: GitHubClientId
+    private lateinit var sessionId: SessionId
     private lateinit var token: PersonalAccessToken
 
     override fun contextBuilder(): BoundedContextBuilder =
@@ -88,7 +94,8 @@ internal class GitHubClientSpec : ContextAwareTest() {
 
     private fun emitUserLoggedInEventInSessionsContext() {
         token = PersonalAccessToken::class.of(randomString())
-        val userLoggedIn = UserLoggedIn::class.buildBy(gitHubClientId.username, token)
+        sessionId = SessionId::class.of(gitHubClientId.username)
+        val userLoggedIn = UserLoggedIn::class.buildBy(sessionId, token)
         sessionContext.receivesEvent(userLoggedIn)
     }
 
@@ -116,6 +123,35 @@ internal class GitHubClientSpec : ContextAwareTest() {
         internal fun `update token in existing 'GitHubClient' entity`() {
             emitUserLoggedInEventInSessionsContext()
             val expected = GitHubClient::class.buildBy(gitHubClientId, token)
+            context().assertState(gitHubClientId, expected)
+        }
+    }
+
+    @Nested internal inner class
+    `React on 'TokenRefreshed' event in Sessions bounded context, and` {
+
+        private lateinit var newToken: PersonalAccessToken
+
+        @BeforeEach
+        internal fun emitTokenRefreshedEvent() {
+            newToken = PersonalAccessToken::class.of(randomString())
+            val event = TokenRefreshed::class.with(sessionId, newToken)
+            sessionContext.receivesEvent(event)
+        }
+
+        @Test
+        internal fun `emit 'GitHubTokenUpdated' event`() {
+            val expected = GitHubTokenUpdated::class.buildBy(gitHubClientId, newToken)
+            val eventSubject = context().assertEvents()
+                .withType(GitHubTokenUpdated::class.java)
+            eventSubject.hasSize(2)
+            eventSubject.message(1)
+                .isEqualTo(expected)
+        }
+
+        @Test
+        internal fun `update token in 'GitHubClient' entity`() {
+            val expected = GitHubClient::class.buildBy(gitHubClientId, newToken)
             context().assertState(gitHubClientId, expected)
         }
     }

--- a/mentions/src/test/kotlin/io/spine/examples/pingh/mentions/GitHubClientSpec.kt
+++ b/mentions/src/test/kotlin/io/spine/examples/pingh/mentions/GitHubClientSpec.kt
@@ -135,7 +135,7 @@ internal class GitHubClientSpec : ContextAwareTest() {
         @BeforeEach
         internal fun emitTokenRefreshedEvent() {
             newToken = PersonalAccessToken::class.of(randomString())
-            val event = TokenRefreshed::class.with(sessionId, newToken)
+            val event = TokenRefreshed::class.with(sessionId, newToken, currentTime())
             sessionContext.receivesEvent(event)
         }
 

--- a/mentions/src/test/kotlin/io/spine/examples/pingh/mentions/given/GitHubClientSpecEnv.kt
+++ b/mentions/src/test/kotlin/io/spine/examples/pingh/mentions/given/GitHubClientSpecEnv.kt
@@ -38,10 +38,6 @@ import io.spine.examples.pingh.mentions.of
 import io.spine.examples.pingh.mentions.command.UpdateMentionsFromGitHub
 import io.spine.examples.pingh.mentions.event.UserMentioned
 import io.spine.examples.pingh.mentions.rejection.GithubClientRejections.MentionsUpdateIsAlreadyInProgress
-import io.spine.examples.pingh.sessions.SessionId
-import io.spine.examples.pingh.sessions.buildBy
-import io.spine.examples.pingh.sessions.of
-import io.spine.examples.pingh.sessions.event.UserLoggedIn
 import io.spine.examples.pingh.testing.mentions.given.predefinedMentionsSet
 import kotlin.reflect.KClass
 
@@ -79,16 +75,6 @@ internal fun KClass<GitHubClient>.buildWithDefaultWhenStartedField(): GitHubClie
         // Building the message partially to include
         // only the tested fields.
         .buildPartial()
-
-/**
- * Creates a new `UserLoggedIn` event with the specified `Username` and `PersonalAccessToken`.
- */
-internal fun KClass<UserLoggedIn>.buildBy(username: Username, token: PersonalAccessToken):
-        UserLoggedIn =
-    this.buildBy(
-        SessionId::class.of(username),
-        token
-    )
 
 /**
  * Creates a new `UpdateMentionsFromGitHub` command with the specified ID of the `GitHubClient`

--- a/server/src/main/kotlin/io/spine/examples/pingh/server/PinghServer.kt
+++ b/server/src/main/kotlin/io/spine/examples/pingh/server/PinghServer.kt
@@ -36,6 +36,7 @@ import io.spine.server.storage.memory.InMemoryStorageFactory
 import io.spine.server.transport.memory.InMemoryTransportFactory
 import io.spine.client.ConnectionConstants.DEFAULT_CLIENT_SERVICE_PORT
 import io.spine.examples.pingh.github.ClientId
+import io.spine.examples.pingh.github.ClientSecret
 import io.spine.examples.pingh.github.of
 import io.spine.examples.pingh.mentions.RemoteGitHubSearch
 import io.spine.examples.pingh.sessions.RemoteGitHubAuthentication
@@ -47,6 +48,13 @@ import io.spine.examples.pingh.sessions.newSessionsContext
 // TODO:2024-07-29:mykyta.pimonov: Load a key from the Google Secret Manager
 //  after deployment to the Google Cloud.
 private val clientId = ClientId::class.of("client_id")
+
+/**
+ * The client secret of the Pingh GitHub App.
+ */
+// TODO:2024-08-28:mykyta.pimonov: Load a key from the Google Secret Manager
+//  after deployment to the Google Cloud.
+private val clientSecret = ClientSecret::class.of("client_id")
 
 /**
  * The entry point of the server application.
@@ -69,7 +77,7 @@ private fun createServer(): Server {
     val clientEngine = CIO.create()
     return Server
         .atPort(DEFAULT_CLIENT_SERVICE_PORT)
-        .add(newSessionsContext(RemoteGitHubAuthentication(clientId, clientEngine)))
+        .add(newSessionsContext(RemoteGitHubAuthentication(clientId, clientSecret, clientEngine)))
         .add(newMentionsContext(RemoteGitHubSearch(clientEngine)))
         .build()
 }

--- a/sessions/build.gradle.kts
+++ b/sessions/build.gradle.kts
@@ -47,6 +47,7 @@ spine {
 
 dependencies {
     implementation(project(":github"))
+    implementation(project(":clock"))
     implementation(JavaX.annotations)
     implementation(Ktor.Client.core)
 

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/CommandsExts.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/CommandsExts.kt
@@ -28,6 +28,7 @@
 
 package io.spine.examples.pingh.sessions
 
+import com.google.protobuf.Timestamp
 import io.spine.examples.pingh.sessions.command.LogUserIn
 import io.spine.examples.pingh.sessions.command.LogUserOut
 import io.spine.examples.pingh.sessions.command.RefreshToken
@@ -51,11 +52,16 @@ public fun KClass<VerifyUserLoginToGitHub>.withSession(id: SessionId): VerifyUse
         .vBuild()
 
 /**
- * Creates a new `RefreshToken` command with the specified ID of the session.
+ * Creates a new `RefreshToken` command with the specified ID of the session and
+ * the time the access token refresh is requested.
  */
-public fun KClass<RefreshToken>.withSession(id: SessionId): RefreshToken =
+public fun KClass<RefreshToken>.with(
+    id: SessionId,
+    whenRequested: Timestamp
+): RefreshToken =
     RefreshToken.newBuilder()
         .setId(id)
+        .setWhenRequested(whenRequested)
         .vBuild()
 
 /**

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/CommandsExts.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/CommandsExts.kt
@@ -30,6 +30,7 @@ package io.spine.examples.pingh.sessions
 
 import io.spine.examples.pingh.sessions.command.LogUserIn
 import io.spine.examples.pingh.sessions.command.LogUserOut
+import io.spine.examples.pingh.sessions.command.RefreshToken
 import io.spine.examples.pingh.sessions.command.VerifyUserLoginToGitHub
 import kotlin.reflect.KClass
 
@@ -46,6 +47,14 @@ public fun KClass<LogUserIn>.withSession(id: SessionId): LogUserIn =
  */
 public fun KClass<VerifyUserLoginToGitHub>.withSession(id: SessionId): VerifyUserLoginToGitHub =
     VerifyUserLoginToGitHub.newBuilder()
+        .setId(id)
+        .vBuild()
+
+/**
+ * Creates a new `RefreshToken` command with the specified ID of the session.
+ */
+public fun KClass<RefreshToken>.withSession(id: SessionId): RefreshToken =
+    RefreshToken.newBuilder()
         .setId(id)
         .vBuild()
 

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/EventsExts.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/EventsExts.kt
@@ -84,11 +84,13 @@ public fun KClass<UserIsNotLoggedIntoGitHub>.withSession(id: SessionId): UserIsN
         .vBuild()
 
 /**
- * Creates a new `TokenRefreshed` event with the specified ID of the session.
+ * Creates a new `TokenRefreshed` event with the specified ID of the session
+ * and `PersonalAccessToken`.
  */
-public fun KClass<TokenRefreshed>.withSession(id: SessionId): TokenRefreshed =
+public fun KClass<TokenRefreshed>.with(id: SessionId, token: PersonalAccessToken): TokenRefreshed =
     TokenRefreshed.newBuilder()
         .setId(id)
+        .setToken(token)
         .vBuild()
 
 /**

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/EventsExts.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/EventsExts.kt
@@ -29,6 +29,7 @@
 package io.spine.examples.pingh.sessions
 
 import com.google.protobuf.Duration
+import com.google.protobuf.Timestamp
 import io.spine.examples.pingh.github.PersonalAccessToken
 import io.spine.examples.pingh.github.UserCode
 import io.spine.examples.pingh.sessions.event.TokenRefreshed
@@ -84,13 +85,18 @@ public fun KClass<UserIsNotLoggedIntoGitHub>.withSession(id: SessionId): UserIsN
         .vBuild()
 
 /**
- * Creates a new `TokenRefreshed` event with the specified ID of the session
- * and `PersonalAccessToken`.
+ * Creates a new `TokenRefreshed` event with the specified ID of the session, `PersonalAccessToken`,
+ * and the time the refresh occurred.
  */
-public fun KClass<TokenRefreshed>.with(id: SessionId, token: PersonalAccessToken): TokenRefreshed =
+public fun KClass<TokenRefreshed>.with(
+    id: SessionId,
+    token: PersonalAccessToken,
+    whenRefreshed: Timestamp
+): TokenRefreshed =
     TokenRefreshed.newBuilder()
         .setId(id)
         .setToken(token)
+        .setWhenRefreshed(whenRefreshed)
         .vBuild()
 
 /**

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/EventsExts.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/EventsExts.kt
@@ -31,6 +31,7 @@ package io.spine.examples.pingh.sessions
 import com.google.protobuf.Duration
 import io.spine.examples.pingh.github.PersonalAccessToken
 import io.spine.examples.pingh.github.UserCode
+import io.spine.examples.pingh.sessions.event.TokenRefreshed
 import io.spine.examples.pingh.sessions.event.UserCodeReceived
 import io.spine.examples.pingh.sessions.event.UserIsNotLoggedIntoGitHub
 import io.spine.examples.pingh.sessions.event.UserLoggedIn
@@ -79,6 +80,14 @@ public fun KClass<UserLoggedIn>.buildBy(id: SessionId, token: PersonalAccessToke
  */
 public fun KClass<UserIsNotLoggedIntoGitHub>.withSession(id: SessionId): UserIsNotLoggedIntoGitHub =
     UserIsNotLoggedIntoGitHub.newBuilder()
+        .setId(id)
+        .vBuild()
+
+/**
+ * Creates a new `TokenRefreshed` event with the specified ID of the session.
+ */
+public fun KClass<TokenRefreshed>.withSession(id: SessionId): TokenRefreshed =
+    TokenRefreshed.newBuilder()
         .setId(id)
         .vBuild()
 

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/GitHubAuthentication.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/GitHubAuthentication.kt
@@ -27,6 +27,7 @@
 package io.spine.examples.pingh.sessions
 
 import io.spine.examples.pingh.github.DeviceCode
+import io.spine.examples.pingh.github.RefreshToken
 import io.spine.examples.pingh.github.UserCode
 import io.spine.examples.pingh.github.rest.AccessTokenResponse
 import io.spine.examples.pingh.github.rest.VerificationCodesResponse
@@ -50,4 +51,11 @@ public interface GitHubAuthentication {
      */
     @Throws(CannotObtainAccessToken::class)
     public fun requestAccessToken(deviceCode: DeviceCode): AccessTokenResponse
+
+    /**
+     * Requests a new access token for the user using the `RefreshToken`.
+     *
+     * @param refreshToken The token to renew the `PersonalAccessToken` when it expires.
+     */
+    public fun refreshAccessToken(refreshToken: RefreshToken): AccessTokenResponse
 }

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/RemoteGitHubAuthentication.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/RemoteGitHubAuthentication.kt
@@ -35,6 +35,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.URLBuilder
 import io.spine.examples.pingh.github.ClientId
 import io.spine.examples.pingh.github.DeviceCode
+import io.spine.examples.pingh.github.RefreshToken
 import io.spine.examples.pingh.github.rest.AccessTokenResponse
 import io.spine.examples.pingh.github.rest.ErrorResponse
 import io.spine.examples.pingh.github.rest.VerificationCodesResponse
@@ -111,6 +112,13 @@ public class RemoteGitHubAuthentication(
         if (possibleErrorMessage.error.isNotEmpty()) {
             throw CannotObtainAccessToken(possibleErrorMessage.error)
         }
+    }
+
+    /**
+     *
+     */
+    override fun refreshAccessToken(refreshToken: RefreshToken): AccessTokenResponse {
+        TODO("Not yet implemented")
     }
 }
 

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/TimestampExts.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/TimestampExts.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.pingh.sessions
+
+import com.google.protobuf.Timestamp
+import com.google.protobuf.util.Timestamps
+
+/**
+ * Compares this `Timestamp` with the passed one.
+ */
+internal operator fun Timestamp.compareTo(other: Timestamp): Int = Timestamps.compare(this, other)

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/TimestampExts.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/TimestampExts.kt
@@ -26,6 +26,7 @@
 
 package io.spine.examples.pingh.sessions
 
+import com.google.protobuf.Duration
 import com.google.protobuf.Timestamp
 import com.google.protobuf.util.Timestamps
 
@@ -33,3 +34,13 @@ import com.google.protobuf.util.Timestamps
  * Compares this `Timestamp` with the passed one.
  */
 internal operator fun Timestamp.compareTo(other: Timestamp): Int = Timestamps.compare(this, other)
+
+/**
+ * Subtracts the passed duration from this timestamp.
+ */
+internal fun Timestamp.subtract(duration: Duration): Timestamp = Timestamps.subtract(this, duration)
+
+/**
+ * Adds the passed duration to this timestamp.
+ */
+internal fun Timestamp.add(duration: Duration): Timestamp = Timestamps.add(this, duration)

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/UserSessionProcess.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/UserSessionProcess.kt
@@ -106,13 +106,13 @@ internal class UserSessionProcess :
     }
 
     /**
-     * Sends a `RefreshToken` command if the process is user logged in
-     * and the personal access token has already expired.
+     * Sends a `RefreshToken` command if the user is logged in
+     * and the personal access token is expired.
      */
     @Command
     internal fun on(@External event: TimePassed): Optional<RefreshToken> {
-        val isLoggedIn = isActive && state().hasRefreshToken()
-        return if (isLoggedIn && event.time >= state().whenAccessTokenExpires) {
+        val isUserLoggedIn = isActive && state().hasRefreshToken()
+        return if (isUserLoggedIn && event.time >= state().whenAccessTokenExpires) {
             Optional.of(RefreshToken::class.withSession(state().id))
         } else {
             Optional.empty()

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/UserSessionProcess.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/UserSessionProcess.kt
@@ -26,8 +26,6 @@
 
 package io.spine.examples.pingh.sessions
 
-import com.google.protobuf.Timestamp
-import com.google.protobuf.util.Timestamps
 import io.spine.core.External
 import io.spine.examples.pingh.clock.event.TimePassed
 import io.spine.examples.pingh.sessions.command.LogUserIn
@@ -152,8 +150,3 @@ internal class UserSessionProcess :
         this.authenticationService = authenticationService
     }
 }
-
-/**
- * Compares this `Timestamp` with the passed one.
- */
-private operator fun Timestamp.compareTo(other: Timestamp): Int = Timestamps.compare(this, other)

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/UserSessionProcess.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/UserSessionProcess.kt
@@ -120,11 +120,16 @@ internal class UserSessionProcess :
     }
 
     /**
-     *
+     * Renews GitHub access tokens using the refresh token.
      */
     @Assign
     internal fun handle(command: RefreshToken): TokenRefreshed {
-        TODO("Not implemented yet.")
+        val tokens = authenticationService.refreshAccessToken(state().refreshToken)
+        with(builder()) {
+            whenAccessTokenExpires = tokens.whenExpires
+            refreshToken = tokens.refreshToken
+        }
+        return TokenRefreshed::class.with(command.id, tokens.accessToken)
     }
 
     /**

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/UserSessionProcess.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/UserSessionProcess.kt
@@ -111,7 +111,7 @@ internal class UserSessionProcess :
     internal fun on(@External event: TimePassed): Optional<RefreshToken> {
         val isUserLoggedIn = isActive && state().hasRefreshToken()
         return if (isUserLoggedIn && event.time >= state().whenAccessTokenExpires) {
-            Optional.of(RefreshToken::class.withSession(state().id))
+            Optional.of(RefreshToken::class.with(state().id, event.time))
         } else {
             Optional.empty()
         }
@@ -127,7 +127,7 @@ internal class UserSessionProcess :
             whenAccessTokenExpires = tokens.whenExpires
             refreshToken = tokens.refreshToken
         }
-        return TokenRefreshed::class.with(command.id, tokens.accessToken)
+        return TokenRefreshed::class.with(command.id, tokens.accessToken, command.whenRequested)
     }
 
     /**

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/UserSessionRepository.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/UserSessionRepository.kt
@@ -27,7 +27,9 @@
 package io.spine.examples.pingh.sessions
 
 import com.google.errorprone.annotations.OverridingMethodsMustInvokeSuper
+import io.spine.examples.pingh.clock.event.TimePassed
 import io.spine.server.procman.ProcessManagerRepository
+import io.spine.server.route.EventRouting
 
 /**
  * Manages instances of [UserSessionProcess].
@@ -37,8 +39,22 @@ internal class UserSessionRepository(
 ) : ProcessManagerRepository<SessionId, UserSessionProcess, UserSession>() {
 
     @OverridingMethodsMustInvokeSuper
+    override fun setupEventRouting(routing: EventRouting<SessionId>) {
+        super.setupEventRouting(routing)
+        routing.route(TimePassed::class.java) { _, _ -> toAll() }
+    }
+
+    @OverridingMethodsMustInvokeSuper
     override fun configure(processManager: UserSessionProcess) {
         super.configure(processManager)
         processManager.inject(authenticationService)
     }
+
+    /**
+     * Returns a set of identifiers of records in the process manager storage.
+     */
+    private fun toAll(): Set<SessionId> =
+        storage().index()
+            .asSequence()
+            .toSet()
 }

--- a/sessions/src/main/proto/spine_examples/pingh/sessions/commands.proto
+++ b/sessions/src/main/proto/spine_examples/pingh/sessions/commands.proto
@@ -36,6 +36,7 @@ option java_multiple_files = true;
 
 import "spine_examples/pingh/sessions/identifiers.proto";
 import "spine_examples/pingh/github/values.proto";
+import "google/protobuf/timestamp.proto";
 
 // Tells to start the login process for a Pingh app via GitHub.
 message LogUserIn {
@@ -57,6 +58,9 @@ message RefreshToken {
 
     // The ID of the user session.
     SessionId id = 1;
+
+    // The time when the access token refresh is requested.
+    google.protobuf.Timestamp when_requested = 2 [(required) = true];
 }
 
 // Tells to log user out.

--- a/sessions/src/main/proto/spine_examples/pingh/sessions/commands.proto
+++ b/sessions/src/main/proto/spine_examples/pingh/sessions/commands.proto
@@ -52,6 +52,13 @@ message VerifyUserLoginToGitHub {
     SessionId id = 1;
 }
 
+// Tells to refresh GitHub personal access token.
+message RefreshToken {
+
+    // The ID of the user session.
+    SessionId id = 1;
+}
+
 // Tells to log user out.
 message LogUserOut {
 

--- a/sessions/src/main/proto/spine_examples/pingh/sessions/events.proto
+++ b/sessions/src/main/proto/spine_examples/pingh/sessions/events.proto
@@ -89,6 +89,9 @@ message TokenRefreshed {
 
     // The GitHub token obtained as a result of the token refresh.
     spine_examples.pingh.github.PersonalAccessToken token = 2 [(required) = true];
+
+    // The time when the access token was refreshed.
+    google.protobuf.Timestamp when_refreshed = 3 [(required) = true];
 }
 
 // The user logged out.

--- a/sessions/src/main/proto/spine_examples/pingh/sessions/events.proto
+++ b/sessions/src/main/proto/spine_examples/pingh/sessions/events.proto
@@ -81,6 +81,16 @@ message UserIsNotLoggedIntoGitHub {
     SessionId id = 1;
 }
 
+// The personal access token was refreshed.
+message TokenRefreshed {
+
+    // The ID of user session.
+    SessionId id = 1;
+
+    // The GitHub token obtained as a result of the token refresh.
+    spine_examples.pingh.github.PersonalAccessToken token = 2 [(required) = true];
+}
+
 // The user logged out.
 message UserLoggedOut {
 

--- a/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/UserSessionSpec.kt
+++ b/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/UserSessionSpec.kt
@@ -28,7 +28,6 @@ package io.spine.examples.pingh.sessions
 
 import com.google.protobuf.Timestamp
 import io.spine.base.Time.currentTime
-import io.spine.core.UserId
 import io.spine.examples.pingh.clock.buildBy
 import io.spine.examples.pingh.clock.event.TimePassed
 import io.spine.examples.pingh.sessions.command.LogUserIn
@@ -50,6 +49,7 @@ import io.spine.examples.pingh.testing.sessions.given.PredefinedGitHubAuthentica
 import io.spine.protobuf.Durations2.minutes
 import io.spine.server.BoundedContextBuilder
 import io.spine.server.integration.ThirdPartyContext
+import io.spine.testing.core.given.GivenUserId
 import io.spine.testing.server.blackbox.ContextAwareTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -186,7 +186,7 @@ internal class UserSessionSpec : ContextAwareTest() {
         private fun emitTimePassedEvent(time: Timestamp = currentTime()) {
             val clockContext = ThirdPartyContext.singleTenant("Clock")
             val event = TimePassed::class.buildBy(time)
-            val actor = UserId::class.generate()
+            val actor = GivenUserId.generated()
             clockContext.emittedEvent(event, actor)
         }
     }

--- a/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/UserSessionSpec.kt
+++ b/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/UserSessionSpec.kt
@@ -177,7 +177,7 @@ internal class UserSessionSpec : ContextAwareTest() {
             logIn(id)
             val time = authenticationService.whenReceivedAccessTokenExpires!!.add(minutes(1))
             emitTimePassedEvent(time)
-            val expected = RefreshToken::class.withSession(id)
+            val expected = RefreshToken::class.with(id, time)
             val commandSubject = context().assertCommands()
                 .withType(RefreshToken::class.java)
             commandSubject.hasSize(1)
@@ -197,18 +197,20 @@ internal class UserSessionSpec : ContextAwareTest() {
     `Handle 'RefreshToken' command, and` {
 
         private lateinit var id: SessionId
+        private lateinit var whenRequested: Timestamp
 
         @BeforeEach
         internal fun sendRefreshTokenCommand() {
             id = SessionId::class.generate()
             logIn(id)
-            val command = RefreshToken::class.withSession(id)
+            whenRequested = currentTime()
+            val command = RefreshToken::class.with(id, whenRequested)
             context().receivesCommand(command)
         }
 
         @Test
         internal fun `emit 'TokenRefreshed' event`() {
-            val expected = expectedTokenRefreshedEvent(id)
+            val expected = expectedTokenRefreshedEvent(id, whenRequested)
             context().assertEvent(expected)
         }
 

--- a/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/UserSessionSpec.kt
+++ b/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/UserSessionSpec.kt
@@ -38,7 +38,6 @@ import io.spine.examples.pingh.sessions.command.VerifyUserLoginToGitHub
 import io.spine.examples.pingh.sessions.event.UserIsNotLoggedIntoGitHub
 import io.spine.examples.pingh.sessions.event.UserLoggedIn
 import io.spine.examples.pingh.sessions.event.UserLoggedOut
-import io.spine.examples.pingh.sessions.given.add
 import io.spine.examples.pingh.sessions.given.expectedTokenRefreshedEvent
 import io.spine.examples.pingh.sessions.given.with
 import io.spine.examples.pingh.sessions.given.expectedUserCodeReceivedEvent
@@ -47,7 +46,6 @@ import io.spine.examples.pingh.sessions.given.expectedUserSessionAfterTokenRefre
 import io.spine.examples.pingh.sessions.given.expectedUserSessionWithDeviceCode
 import io.spine.examples.pingh.sessions.given.expectedUserSessionWithRefreshToken
 import io.spine.examples.pingh.sessions.given.generate
-import io.spine.examples.pingh.sessions.given.subtract
 import io.spine.examples.pingh.testing.sessions.given.PredefinedGitHubAuthenticationResponses
 import io.spine.protobuf.Durations2.minutes
 import io.spine.server.BoundedContextBuilder

--- a/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/UserSessionSpec.kt
+++ b/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/UserSessionSpec.kt
@@ -213,7 +213,7 @@ internal class UserSessionSpec : ContextAwareTest() {
         }
 
         @Test
-        internal fun `update refresh token and access token expiration time in 'UserSession'`() {
+        internal fun `update refresh token in 'UserSession' entity`() {
             val expected = expectedUserSessionAfterTokenRefresh(id)
             context().assertState(id, expected)
         }

--- a/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/given/UserSessionSpecEnv.kt
+++ b/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/given/UserSessionSpecEnv.kt
@@ -28,10 +28,7 @@
 
 package io.spine.examples.pingh.sessions.given
 
-import com.google.protobuf.Duration
 import com.google.protobuf.Timestamp
-import com.google.protobuf.util.Timestamps.add
-import com.google.protobuf.util.Timestamps.subtract
 import io.spine.core.UserId
 import io.spine.examples.pingh.github.DeviceCode
 import io.spine.examples.pingh.github.RefreshToken
@@ -140,13 +137,3 @@ internal fun KClass<UserId>.generate(): UserId =
     UserId.newBuilder()
         .setValue(randomString())
         .vBuild()
-
-/**
- * Subtracts the passed duration from this timestamp.
- */
-internal fun Timestamp.subtract(duration: Duration): Timestamp = subtract(this, duration)
-
-/**
- * Adds the passed duration to this timestamp.
- */
-internal fun Timestamp.add(duration: Duration): Timestamp = add(this, duration)

--- a/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/given/UserSessionSpecEnv.kt
+++ b/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/given/UserSessionSpecEnv.kt
@@ -46,9 +46,9 @@ import io.spine.examples.pingh.sessions.event.TokenRefreshed
 import io.spine.examples.pingh.sessions.event.UserCodeReceived
 import io.spine.examples.pingh.sessions.event.UserLoggedIn
 import io.spine.examples.pingh.sessions.with
-import io.spine.examples.pingh.testing.sessions.given.predefinedAccessTokenResponse
-import io.spine.examples.pingh.testing.sessions.given.predefinedRefreshedAccessTokenResponse
-import io.spine.examples.pingh.testing.sessions.given.predefinedVerificationCodes
+import io.spine.examples.pingh.testing.sessions.given.loadAccessToken
+import io.spine.examples.pingh.testing.sessions.given.loadRefreshedAccessToken
+import io.spine.examples.pingh.testing.sessions.given.loadVerificationCodes
 import io.spine.testing.TestValues.randomString
 import kotlin.reflect.KClass
 
@@ -84,7 +84,7 @@ internal fun KClass<UserSession>.with(
  * from the predefined GitHub response.
  */
 internal fun expectedUserSessionWithDeviceCode(id: SessionId): UserSession =
-    with(predefinedVerificationCodes()) {
+    with(loadVerificationCodes()) {
         UserSession::class.with(id, deviceCode)
     }
 
@@ -93,7 +93,7 @@ internal fun expectedUserSessionWithDeviceCode(id: SessionId): UserSession =
  * from the predefined GitHub response.
  */
 internal fun expectedUserSessionWithRefreshToken(id: SessionId): UserSession =
-    with(predefinedAccessTokenResponse()) {
+    with(loadAccessToken()) {
         UserSession::class.with(id, refreshToken = refreshToken)
     }
 
@@ -102,7 +102,7 @@ internal fun expectedUserSessionWithRefreshToken(id: SessionId): UserSession =
  * from the predefined GitHub response to the token update request.
  */
 internal fun expectedUserSessionAfterTokenRefresh(id: SessionId): UserSession =
-    with(predefinedRefreshedAccessTokenResponse()) {
+    with(loadRefreshedAccessToken()) {
         UserSession::class.with(id, refreshToken = refreshToken)
     }
 
@@ -111,7 +111,7 @@ internal fun expectedUserSessionAfterTokenRefresh(id: SessionId): UserSession =
  * data from the predefined GitHub response.
  */
 internal fun expectedUserCodeReceivedEvent(id: SessionId): UserCodeReceived =
-    with(predefinedVerificationCodes()) {
+    with(loadVerificationCodes()) {
         UserCodeReceived::class.buildWith(id, userCode, verificationUrl, expiresIn, interval)
     }
 
@@ -120,7 +120,7 @@ internal fun expectedUserCodeReceivedEvent(id: SessionId): UserCodeReceived =
  * data from the predefined GitHub response.
  */
 internal fun expectedUserLoggedInEvent(id: SessionId): UserLoggedIn =
-    with(predefinedAccessTokenResponse()) {
+    with(loadAccessToken()) {
         UserLoggedIn::class.buildBy(id, accessToken)
     }
 
@@ -129,7 +129,7 @@ internal fun expectedUserLoggedInEvent(id: SessionId): UserLoggedIn =
  * data from the predefined GitHub response.
  */
 internal fun expectedTokenRefreshedEvent(id: SessionId): TokenRefreshed =
-    with(predefinedRefreshedAccessTokenResponse()) {
+    with(loadRefreshedAccessToken()) {
         TokenRefreshed::class.with(id, accessToken)
     }
 

--- a/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/given/UserSessionSpecEnv.kt
+++ b/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/given/UserSessionSpecEnv.kt
@@ -125,12 +125,12 @@ internal fun expectedUserLoggedInEvent(id: SessionId): UserLoggedIn =
     }
 
 /**
- * Creates a new `TokenRefreshed` event with the passed session ID and
- * data from the predefined GitHub response.
+ * Creates a new `TokenRefreshed` event with the passed session ID,
+ * the time the access token was refreshed, and data from the predefined GitHub response.
  */
-internal fun expectedTokenRefreshedEvent(id: SessionId): TokenRefreshed =
+internal fun expectedTokenRefreshedEvent(id: SessionId, whenRefreshed: Timestamp): TokenRefreshed =
     with(loadRefreshedAccessToken()) {
-        TokenRefreshed::class.with(id, accessToken)
+        TokenRefreshed::class.with(id, accessToken, whenRefreshed)
     }
 
 /**

--- a/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/given/UserSessionSpecEnv.kt
+++ b/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/given/UserSessionSpecEnv.kt
@@ -98,7 +98,7 @@ internal fun expectedUserSessionWithRefreshToken(id: SessionId): UserSession =
     }
 
 /**
- * Creates a new `UserSession` with the specified session ID and refresh token
+ * Creates a new `UserSession` with the passed session ID and refresh token
  * from the predefined GitHub response to the token update request.
  */
 internal fun expectedUserSessionAfterTokenRefresh(id: SessionId): UserSession =
@@ -125,7 +125,7 @@ internal fun expectedUserLoggedInEvent(id: SessionId): UserLoggedIn =
     }
 
 /**
- * Creates a new `TokenRefreshed` event with the specified session ID and
+ * Creates a new `TokenRefreshed` event with the passed session ID and
  * data from the predefined GitHub response.
  */
 internal fun expectedTokenRefreshedEvent(id: SessionId): TokenRefreshed =

--- a/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/given/UserSessionSpecEnv.kt
+++ b/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/given/UserSessionSpecEnv.kt
@@ -42,9 +42,12 @@ import io.spine.examples.pingh.sessions.UserSession
 import io.spine.examples.pingh.sessions.buildBy
 import io.spine.examples.pingh.sessions.of
 import io.spine.examples.pingh.sessions.buildWith
+import io.spine.examples.pingh.sessions.event.TokenRefreshed
 import io.spine.examples.pingh.sessions.event.UserCodeReceived
 import io.spine.examples.pingh.sessions.event.UserLoggedIn
+import io.spine.examples.pingh.sessions.with
 import io.spine.examples.pingh.testing.sessions.given.predefinedAccessTokenResponse
+import io.spine.examples.pingh.testing.sessions.given.predefinedRefreshedAccessTokenResponse
 import io.spine.examples.pingh.testing.sessions.given.predefinedVerificationCodes
 import io.spine.testing.TestValues.randomString
 import kotlin.reflect.KClass
@@ -95,6 +98,15 @@ internal fun expectedUserSessionWithRefreshToken(id: SessionId): UserSession =
     }
 
 /**
+ * Creates a new `UserSession` with the specified session ID and refresh token
+ * from the predefined GitHub response to the token update request.
+ */
+internal fun expectedUserSessionAfterTokenRefresh(id: SessionId): UserSession =
+    with(predefinedRefreshedAccessTokenResponse()) {
+        UserSession::class.with(id, refreshToken = refreshToken)
+    }
+
+/**
  * Creates a new `UserCodeReceived` event with the specified session ID and
  * data from the predefined GitHub response.
  */
@@ -110,6 +122,15 @@ internal fun expectedUserCodeReceivedEvent(id: SessionId): UserCodeReceived =
 internal fun expectedUserLoggedInEvent(id: SessionId): UserLoggedIn =
     with(predefinedAccessTokenResponse()) {
         UserLoggedIn::class.buildBy(id, accessToken)
+    }
+
+/**
+ * Creates a new `TokenRefreshed` event with the specified session ID and
+ * data from the predefined GitHub response.
+ */
+internal fun expectedTokenRefreshedEvent(id: SessionId): TokenRefreshed =
+    with(predefinedRefreshedAccessTokenResponse()) {
+        TokenRefreshed::class.with(id, accessToken)
     }
 
 /**

--- a/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/given/UserSessionSpecEnv.kt
+++ b/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/given/UserSessionSpecEnv.kt
@@ -29,7 +29,6 @@
 package io.spine.examples.pingh.sessions.given
 
 import com.google.protobuf.Timestamp
-import io.spine.core.UserId
 import io.spine.examples.pingh.github.DeviceCode
 import io.spine.examples.pingh.github.RefreshToken
 import io.spine.examples.pingh.github.Username
@@ -129,11 +128,3 @@ internal fun expectedTokenRefreshedEvent(id: SessionId, whenRefreshed: Timestamp
     with(loadRefreshedAccessToken()) {
         TokenRefreshed::class.with(id, accessToken, whenRefreshed)
     }
-
-/**
- * Creates a new `UserId` with the randomly specified value.
- */
-internal fun KClass<UserId>.generate(): UserId =
-    UserId.newBuilder()
-        .setValue(randomString())
-        .vBuild()

--- a/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/given/UserSessionSpecEnv.kt
+++ b/sessions/src/test/kotlin/io/spine/examples/pingh/sessions/given/UserSessionSpecEnv.kt
@@ -28,6 +28,11 @@
 
 package io.spine.examples.pingh.sessions.given
 
+import com.google.protobuf.Duration
+import com.google.protobuf.Timestamp
+import com.google.protobuf.util.Timestamps.add
+import com.google.protobuf.util.Timestamps.subtract
+import io.spine.core.UserId
 import io.spine.examples.pingh.github.DeviceCode
 import io.spine.examples.pingh.github.RefreshToken
 import io.spine.examples.pingh.github.Username
@@ -106,3 +111,21 @@ internal fun expectedUserLoggedInEvent(id: SessionId): UserLoggedIn =
     with(predefinedAccessTokenResponse()) {
         UserLoggedIn::class.buildBy(id, accessToken)
     }
+
+/**
+ * Creates a new `UserId` with the randomly specified value.
+ */
+internal fun KClass<UserId>.generate(): UserId =
+    UserId.newBuilder()
+        .setValue(randomString())
+        .vBuild()
+
+/**
+ * Subtracts the passed duration from this timestamp.
+ */
+internal fun Timestamp.subtract(duration: Duration): Timestamp = subtract(this, duration)
+
+/**
+ * Adds the passed duration to this timestamp.
+ */
+internal fun Timestamp.add(duration: Duration): Timestamp = add(this, duration)

--- a/testutil-sessions/src/main/kotlin/io/spine/examples/pingh/testing/sessions/given/PredefinedGitHubAuthenticationResponses.kt
+++ b/testutil-sessions/src/main/kotlin/io/spine/examples/pingh/testing/sessions/given/PredefinedGitHubAuthenticationResponses.kt
@@ -26,6 +26,7 @@
 
 package io.spine.examples.pingh.testing.sessions.given
 
+import com.google.protobuf.Timestamp
 import io.spine.examples.pingh.github.DeviceCode
 import io.spine.examples.pingh.github.rest.AccessTokenResponse
 import io.spine.examples.pingh.github.rest.VerificationCodesResponse
@@ -47,6 +48,12 @@ public class PredefinedGitHubAuthenticationResponses : GitHubAuthentication {
     private var isUserCodeEntered = false
 
     /**
+     * The expiration time when the personal access token issued by GitHub.
+     */
+    public var whenReceivedAccessTokenExpires: Timestamp? = null
+        private set
+
+    /**
      * Returns `VerificationCodesResponse` retrieved from a JSON file in the resource folder.
      */
     public override fun requestVerificationCodes(): VerificationCodesResponse =
@@ -60,7 +67,9 @@ public class PredefinedGitHubAuthenticationResponses : GitHubAuthentication {
     @Throws(CannotObtainAccessToken::class)
     public override fun requestAccessToken(deviceCode: DeviceCode): AccessTokenResponse =
         if (isUserCodeEntered) {
-            predefinedAccessTokenResponse()
+            val tokens = predefinedAccessTokenResponse()
+            whenReceivedAccessTokenExpires = tokens.whenExpires
+            tokens
         } else {
             throw CannotObtainAccessToken("authorization_pending")
         }

--- a/testutil-sessions/src/main/kotlin/io/spine/examples/pingh/testing/sessions/given/PredefinedGitHubAuthenticationResponses.kt
+++ b/testutil-sessions/src/main/kotlin/io/spine/examples/pingh/testing/sessions/given/PredefinedGitHubAuthenticationResponses.kt
@@ -28,6 +28,7 @@ package io.spine.examples.pingh.testing.sessions.given
 
 import com.google.protobuf.Timestamp
 import io.spine.examples.pingh.github.DeviceCode
+import io.spine.examples.pingh.github.RefreshToken
 import io.spine.examples.pingh.github.rest.AccessTokenResponse
 import io.spine.examples.pingh.github.rest.VerificationCodesResponse
 import io.spine.examples.pingh.sessions.CannotObtainAccessToken
@@ -75,6 +76,15 @@ public class PredefinedGitHubAuthenticationResponses : GitHubAuthentication {
         }
 
     /**
+     * Returns the `AccessTokenResponse` retrieved from a JSON file in the resource folder.
+     */
+    override fun refreshAccessToken(refreshToken: RefreshToken): AccessTokenResponse {
+        val tokens = predefinedRefreshedAccessTokenResponse()
+        whenReceivedAccessTokenExpires = tokens.whenExpires
+        return tokens
+    }
+
+    /**
      * Marks that the user has entered their user code.
      *
      * After calling this method, the login verification will be successful.
@@ -90,5 +100,6 @@ public class PredefinedGitHubAuthenticationResponses : GitHubAuthentication {
      */
     public fun clean() {
         isUserCodeEntered = false
+        whenReceivedAccessTokenExpires = null
     }
 }

--- a/testutil-sessions/src/main/kotlin/io/spine/examples/pingh/testing/sessions/given/PredefinedGitHubAuthenticationResponses.kt
+++ b/testutil-sessions/src/main/kotlin/io/spine/examples/pingh/testing/sessions/given/PredefinedGitHubAuthenticationResponses.kt
@@ -58,7 +58,7 @@ public class PredefinedGitHubAuthenticationResponses : GitHubAuthentication {
      * Returns `VerificationCodesResponse` retrieved from a JSON file in the resource folder.
      */
     public override fun requestVerificationCodes(): VerificationCodesResponse =
-        predefinedVerificationCodes()
+        loadVerificationCodes()
 
     /**
      * Returns the `AccessTokenResponse` retrieved from a JSON file in the resource folder
@@ -68,7 +68,7 @@ public class PredefinedGitHubAuthenticationResponses : GitHubAuthentication {
     @Throws(CannotObtainAccessToken::class)
     public override fun requestAccessToken(deviceCode: DeviceCode): AccessTokenResponse =
         if (isUserCodeEntered) {
-            val tokens = predefinedAccessTokenResponse()
+            val tokens = loadAccessToken()
             whenReceivedAccessTokenExpires = tokens.whenExpires
             tokens
         } else {
@@ -79,7 +79,7 @@ public class PredefinedGitHubAuthenticationResponses : GitHubAuthentication {
      * Returns the `AccessTokenResponse` retrieved from a JSON file in the resource folder.
      */
     override fun refreshAccessToken(refreshToken: RefreshToken): AccessTokenResponse {
-        val tokens = predefinedRefreshedAccessTokenResponse()
+        val tokens = loadRefreshedAccessToken()
         whenReceivedAccessTokenExpires = tokens.whenExpires
         return tokens
     }

--- a/testutil-sessions/src/main/kotlin/io/spine/examples/pingh/testing/sessions/given/PredefinedGitHubAuthenticationResponses.kt
+++ b/testutil-sessions/src/main/kotlin/io/spine/examples/pingh/testing/sessions/given/PredefinedGitHubAuthenticationResponses.kt
@@ -49,7 +49,7 @@ public class PredefinedGitHubAuthenticationResponses : GitHubAuthentication {
     private var isUserCodeEntered = false
 
     /**
-     * The expiration time when the personal access token issued by GitHub.
+     * The time when the personal access token issued by GitHub expires.
      */
     public var whenReceivedAccessTokenExpires: Timestamp? = null
         private set

--- a/testutil-sessions/src/main/kotlin/io/spine/examples/pingh/testing/sessions/given/PredefinedResponses.kt
+++ b/testutil-sessions/src/main/kotlin/io/spine/examples/pingh/testing/sessions/given/PredefinedResponses.kt
@@ -53,3 +53,15 @@ public fun predefinedAccessTokenResponse(): AccessTokenResponse {
     val json = jsonFile.readText()
     return AccessTokenResponse::class.parseJson(json)
 }
+
+/**
+ * Returns the response provided by [PredefinedGitHubAuthenticationResponses]
+ * upon successful execution of the request for refresh access token.
+ */
+public fun predefinedRefreshedAccessTokenResponse(): AccessTokenResponse {
+    val jsonFile = PredefinedGitHubAuthenticationResponses::class.java
+        .getResource("/github-responses/refreshed-access-token-response.json")
+    checkNotNull(jsonFile)
+    val json = jsonFile.readText()
+    return AccessTokenResponse::class.parseJson(json)
+}

--- a/testutil-sessions/src/main/kotlin/io/spine/examples/pingh/testing/sessions/given/PredefinedResponses.kt
+++ b/testutil-sessions/src/main/kotlin/io/spine/examples/pingh/testing/sessions/given/PredefinedResponses.kt
@@ -34,7 +34,7 @@ import io.spine.examples.pingh.sessions.parseJson
  * Returns the response provided by [PredefinedGitHubAuthenticationResponses]
  * upon successful execution of the request for generate verification codes.
  */
-public fun predefinedVerificationCodes(): VerificationCodesResponse {
+public fun loadVerificationCodes(): VerificationCodesResponse {
     val jsonFile = PredefinedGitHubAuthenticationResponses::class.java
         .getResource("/github-responses/authentication-codes-response.json")
     checkNotNull(jsonFile)
@@ -46,7 +46,7 @@ public fun predefinedVerificationCodes(): VerificationCodesResponse {
  * Returns the response provided by [PredefinedGitHubAuthenticationResponses]
  * upon successful execution of the request for generate access token.
  */
-public fun predefinedAccessTokenResponse(): AccessTokenResponse {
+public fun loadAccessToken(): AccessTokenResponse {
     val jsonFile = PredefinedGitHubAuthenticationResponses::class.java
         .getResource("/github-responses/access-token-response.json")
     checkNotNull(jsonFile)
@@ -58,7 +58,7 @@ public fun predefinedAccessTokenResponse(): AccessTokenResponse {
  * Returns the response provided by [PredefinedGitHubAuthenticationResponses]
  * upon successful execution of the request for refresh access token.
  */
-public fun predefinedRefreshedAccessTokenResponse(): AccessTokenResponse {
+public fun loadRefreshedAccessToken(): AccessTokenResponse {
     val jsonFile = PredefinedGitHubAuthenticationResponses::class.java
         .getResource("/github-responses/refreshed-access-token-response.json")
     checkNotNull(jsonFile)

--- a/testutil-sessions/src/main/resources/github-responses/refreshed-access-token-response.json
+++ b/testutil-sessions/src/main/resources/github-responses/refreshed-access-token-response.json
@@ -1,0 +1,8 @@
+{
+  "access_token": "ghu__refreshed_access_token",
+  "expires_in": 28800,
+  "refresh_token": "ghr__refreshed_refresh_token",
+  "refresh_token_expires_in": 15897600,
+  "scope": "",
+  "token_type": "bearer"
+}


### PR DESCRIPTION
The access tokens that GitHub issues upon request for the GitHub App expire after 8 hours. Then a user needs to either log in again to get a new token or update the current token using a refresh token.

This changeset implements automatic updating of personal access tokens using refresh tokens. Once the access token expires, a request to renew the token using a refresh token is executed.

The automatic access tokens refresh flow is defined according to the Event Storming session:

<img width="721" alt="Screenshot 2024-08-28 at 18 38 25" src="https://github.com/user-attachments/assets/9b6c9b96-16c6-4f75-9e6a-101a22fed98d">

