### PR TITLE
Improve the search for mentions on GitHub

### DIFF
--- a/github/src/main/kotlin/io/spine/examples/pingh/github/ValuesExts.kt
+++ b/github/src/main/kotlin/io/spine/examples/pingh/github/ValuesExts.kt
@@ -35,6 +35,7 @@ import io.spine.examples.pingh.github.rest.AccessTokenResponse
 import io.spine.examples.pingh.github.rest.CommentFragment
 import io.spine.examples.pingh.github.rest.IssueOrPullRequestFragment
 import io.spine.examples.pingh.github.rest.OrganizationFragment
+import io.spine.examples.pingh.github.rest.ReviewFragment
 import io.spine.examples.pingh.github.rest.UserFragment
 import io.spine.examples.pingh.github.rest.VerificationCodesFragment
 import io.spine.examples.pingh.github.rest.VerificationCodesResponse
@@ -92,9 +93,20 @@ public fun KClass<User>.of(username: String, avatarUrl: String): User =
     )
 
 /**
+ * Returns the `Repo` where this issue or pull request was created.
+ */
+public fun IssueOrPullRequestFragment.repo(): Repo {
+    val pathSegments = htmlUrl.substring("https://".length).split("/")
+    return Repo.newBuilder()
+        .setOwner(pathSegments[1])
+        .setName(pathSegments[2])
+        .vBuild()
+}
+
+/**
  * Creates a new `Mention` with the data specified in the `IssueOrPullRequestFragment`.
  */
-public fun KClass<Mention>.fromFragment(fragment: IssueOrPullRequestFragment): Mention =
+public fun KClass<Mention>.from(fragment: IssueOrPullRequestFragment): Mention =
     with(Mention.newBuilder()) {
         id = NodeId::class.of(fragment.nodeId)
         author = User::class.of(
@@ -116,18 +128,37 @@ public fun KClass<Mention>.fromFragment(fragment: IssueOrPullRequestFragment): M
  * a mention's title. It is recommended to use the GitHub title of the item
  * under which the comment is made.
  */
-public fun KClass<Mention>.fromFragment(
-    fragment: CommentFragment,
-    itemTitle: String
-): Mention =
+public fun KClass<Mention>.from(fragment: CommentFragment, itemTitle: String): Mention =
     with(Mention.newBuilder()) {
         id = NodeId::class.of(fragment.nodeId)
         author = User::class.of(
             fragment.whoCreated.username,
             fragment.whoCreated.avatarUrl
         )
-        title = itemTitle
+        title = "Comment on $itemTitle"
         whenMentioned = Timestamps.parse(fragment.whenCreated)
+        url = Url::class.of(fragment.htmlUrl)
+        vBuild()
+    }
+
+/**
+ * Creates a new `Mention` with the passed title value and
+ * the data specified in the `ReviewFragment`.
+ *
+ * Reviews do not have titles, which are required to create a `Mention`s.
+ * Therefore, it is necessary to additionally specify which value is considered
+ * a mention's title. It is recommended to use the GitHub title of the pull request
+ * under which the review is submitted.
+ */
+public fun KClass<Mention>.from(fragment: ReviewFragment, prTitle: String): Mention =
+    with(Mention.newBuilder()) {
+        id = NodeId::class.of(fragment.nodeId)
+        author = User::class.of(
+            fragment.whoCreated.username,
+            fragment.whoCreated.avatarUrl
+        )
+        title = "Review of $prTitle"
+        whenMentioned = Timestamps.parse(fragment.whenSubmitted)
         url = Url::class.of(fragment.htmlUrl)
         vBuild()
     }

--- a/github/src/main/kotlin/io/spine/examples/pingh/github/ValuesExts.kt
+++ b/github/src/main/kotlin/io/spine/examples/pingh/github/ValuesExts.kt
@@ -147,8 +147,8 @@ public fun KClass<Mention>.from(fragment: CommentFragment, itemTitle: String): M
  *
  * Reviews do not have titles, which are required to create a `Mention`s.
  * Therefore, it is necessary to additionally specify which value is considered
- * a mention's title. It is recommended to use the GitHub title of the pull request
- * under which the review is submitted.
+ * a mention's title. It is recommended to use the title of the pull request for
+ * which the review is submitted.
  */
 public fun KClass<Mention>.from(fragment: ReviewFragment, prTitle: String): Mention =
     with(Mention.newBuilder()) {

--- a/github/src/main/proto/spine_examples/pingh/github/rest/fragments.proto
+++ b/github/src/main/proto/spine_examples/pingh/github/rest/fragments.proto
@@ -95,7 +95,7 @@ message IssueOrPullRequestFragment {
 // Request to the GitHub API to retrieve them is the same and returns a list containing
 // both issues and pull requests.
 //
-message IssuesAndPullRequestsSearchResult {
+message IssuesAndPullRequestsSearchResponse {
 
     // GitHub items on which the mention occurred.
     //
@@ -169,7 +169,7 @@ message ReviewFragment {
 }
 
 // The GitHub REST API response received when obtaining pull request reviews by the URL.
-message ReviewResponse {
+message ReviewsResponse {
 
     // GitHub pull request reviews.
     //

--- a/github/src/main/proto/spine_examples/pingh/github/rest/fragments.proto
+++ b/github/src/main/proto/spine_examples/pingh/github/rest/fragments.proto
@@ -86,6 +86,9 @@ message IssueOrPullRequestFragment {
 
     // The URL of all comments under this item.
     string comments_url = 7 [(required) = true, json_name = "comments_url"];
+
+    // The number of this item in repository.
+    int64 number = 8 [(required) = true, (min).value = "1"];
 }
 
 // The GitHub API response received when searching for mentions
@@ -139,6 +142,43 @@ message CommentsResponse {
     // If a GitHub item has no comments, the list is empty.
     //
     repeated CommentFragment item = 1 [(validate) = true];
+}
+
+// Pull request review data received via GitHub REST API.
+message ReviewFragment {
+
+    // The review's ID in GitHub.
+    //
+    // To avoid conflicts with the `id` field in the JSON response received from GitHub,
+    // the name `node_id` is used.
+    //
+    string node_id = 1 [(required) = true, json_name = "node_id"];
+
+    // The reviewer.
+    UserFragment who_created = 2 [(required) = true, json_name = "user"];
+
+    // The time when this review was submitted.
+    string when_submitted = 3 [(required) = true, json_name = "submitted_at"];
+
+    // The text body of this review.
+    string body = 4 [(required) = true];
+
+    // The URL of this GitHub review.
+    //
+    // To avoid conflicts with the `url` field in the JSON response received from GitHub,
+    // the name `html_url` is used.
+    //
+    string html_url = 5 [(required) = true, json_name = "html_url"];
+}
+
+// The GitHub REST API response received when obtaining pull request reviews by the URL.
+message ReviewResponse {
+
+    // GitHub pull request reviews.
+    //
+    // If a GitHub pull request has no reviews, the list is empty.
+    //
+    repeated ReviewFragment item = 1 [(validate) = true];
 }
 
 // The GitHub REST API response received when obtaining verification codes.

--- a/github/src/main/proto/spine_examples/pingh/github/rest/fragments.proto
+++ b/github/src/main/proto/spine_examples/pingh/github/rest/fragments.proto
@@ -85,7 +85,7 @@ message IssueOrPullRequestFragment {
     string html_url = 6 [(required) = true, json_name = "html_url"];
 
     // The number of this item in repository.
-    int64 number = 7 [(required) = true, (min).value = "1"];
+    int32 number = 7 [(required) = true, (min).value = "1"];
 }
 
 // The GitHub API response received when searching for mentions
@@ -97,11 +97,14 @@ message IssueOrPullRequestFragment {
 //
 message IssuesAndPullRequestsSearchResponse {
 
+    // The total number of issues and pull requests found.
+    int32 total_count = 1 [(required) = true, (min).value = "0", json_name = "total_count"];
+
     // GitHub items on which the mention occurred.
     //
     // No results may be found for a search request, in this case the list is empty.
     //
-    repeated IssueOrPullRequestFragment item = 1 [(validate) = true, json_name = "items"];
+    repeated IssueOrPullRequestFragment item = 2 [(validate) = true, json_name = "items"];
 }
 
 // Comment data received via GitHub API.

--- a/github/src/main/proto/spine_examples/pingh/github/rest/fragments.proto
+++ b/github/src/main/proto/spine_examples/pingh/github/rest/fragments.proto
@@ -84,11 +84,8 @@ message IssueOrPullRequestFragment {
     //
     string html_url = 6 [(required) = true, json_name = "html_url"];
 
-    // The URL of all comments under this item.
-    string comments_url = 7 [(required) = true, json_name = "comments_url"];
-
     // The number of this item in repository.
-    int64 number = 8 [(required) = true, (min).value = "1"];
+    int64 number = 7 [(required) = true, (min).value = "1"];
 }
 
 // The GitHub API response received when searching for mentions

--- a/github/src/main/proto/spine_examples/pingh/github/values.proto
+++ b/github/src/main/proto/spine_examples/pingh/github/values.proto
@@ -134,3 +134,13 @@ message OrganizationLogin {
 
     string value = 1 [(required) = true];
 }
+
+// A GitHub repository information.
+message Repo {
+
+    // The name of the GitHub repository.
+    string name = 1 [(required) = true];
+
+    // The name of user or organization which is owner of this repo.
+    string owner = 2 [(required) = true];
+}

--- a/github/src/main/proto/spine_examples/pingh/github/values.proto
+++ b/github/src/main/proto/spine_examples/pingh/github/values.proto
@@ -141,6 +141,6 @@ message Repo {
     // The name of the GitHub repository.
     string name = 1 [(required) = true];
 
-    // The name of user or organization which is owner of this repo.
+    // The name of user or organization which is owner of this repository.
     string owner = 2 [(required) = true];
 }

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubResponseParser.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubResponseParser.kt
@@ -29,19 +29,19 @@
 package io.spine.examples.pingh.mentions
 
 import io.spine.examples.pingh.github.rest.CommentsResponse
-import io.spine.examples.pingh.github.rest.IssuesAndPullRequestsSearchResult
-import io.spine.examples.pingh.github.rest.ReviewResponse
+import io.spine.examples.pingh.github.rest.IssuesAndPullRequestsSearchResponse
+import io.spine.examples.pingh.github.rest.ReviewsResponse
 import io.spine.json.Json
 import kotlin.reflect.KClass
 
 /**
- * Parses `IssuesAndPullRequestsSearchResult` from the JSON.
+ * Parses `IssuesAndPullRequestsSearchResponse` from the JSON.
  *
- * @param json The string containing JSON with the `IssuesAndPullRequestsSearchResult`.
+ * @param json The string containing JSON with the `IssuesAndPullRequestsSearchResponse`.
  */
-public fun KClass<IssuesAndPullRequestsSearchResult>.parseJson(json: String):
-        IssuesAndPullRequestsSearchResult =
-    Json.fromJson(json, IssuesAndPullRequestsSearchResult::class.java)
+public fun KClass<IssuesAndPullRequestsSearchResponse>.parseJson(json: String):
+        IssuesAndPullRequestsSearchResponse =
+    Json.fromJson(json, IssuesAndPullRequestsSearchResponse::class.java)
 
 /**
  * Parses `CommentsResponse` from the JSON.
@@ -52,9 +52,9 @@ public fun KClass<CommentsResponse>.parseJson(json: String): CommentsResponse =
     Json.fromJson(json, CommentsResponse::class.java)
 
 /**
- * Parses `ReviewResponse` from the JSON.
+ * Parses `ReviewsResponse` from the JSON.
  *
- * @param json The string containing JSON with the `ReviewResponse`.
+ * @param json The string containing JSON with the `ReviewsResponse`.
  */
-public fun KClass<ReviewResponse>.parseJson(json: String): ReviewResponse =
-    Json.fromJson(json, ReviewResponse::class.java)
+public fun KClass<ReviewsResponse>.parseJson(json: String): ReviewsResponse =
+    Json.fromJson(json, ReviewsResponse::class.java)

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubResponseParser.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubResponseParser.kt
@@ -30,6 +30,7 @@ package io.spine.examples.pingh.mentions
 
 import io.spine.examples.pingh.github.rest.CommentsResponse
 import io.spine.examples.pingh.github.rest.IssuesAndPullRequestsSearchResult
+import io.spine.examples.pingh.github.rest.ReviewResponse
 import io.spine.json.Json
 import kotlin.reflect.KClass
 
@@ -43,9 +44,17 @@ public fun KClass<IssuesAndPullRequestsSearchResult>.parseJson(json: String):
     Json.fromJson(json, IssuesAndPullRequestsSearchResult::class.java)
 
 /**
- * Parses `CommentsGetResult` from the JSON.
+ * Parses `CommentsResponse` from the JSON.
  *
- * @param json The string containing JSON with the `CommentsGetResult`.
+ * @param json The string containing JSON with the `CommentsResponse`.
  */
 public fun KClass<CommentsResponse>.parseJson(json: String): CommentsResponse =
     Json.fromJson(json, CommentsResponse::class.java)
+
+/**
+ * Parses `ReviewResponse` from the JSON.
+ *
+ * @param json The string containing JSON with the `ReviewResponse`.
+ */
+public fun KClass<ReviewResponse>.parseJson(json: String): ReviewResponse =
+    Json.fromJson(json, ReviewResponse::class.java)

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/RemoteGitHubSearch.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/RemoteGitHubSearch.kt
@@ -176,8 +176,9 @@ public class RemoteGitHubSearch(engine: HttpClientEngine) : GitHubSearch {
 }
 
 /**
- * GitHub item type. Contains the name by which they can be searching in the GitHub API
- * using the `is:` filter.
+ * GitHub item type.
+ *
+ * Contains the name by which they can be searching in the GitHub REST API using the `is:` filter.
  */
 private enum class ItemType(val value: String) {
     ISSUE("issue"),
@@ -187,8 +188,8 @@ private enum class ItemType(val value: String) {
 /**
  * Creates a search request builder.
  */
-private fun HttpClient.search(url: String): GitHubSearchRequest =
-    GitHubSearchRequest(this, url)
+private fun HttpClient.search(url: String): SearchRequestBuilder =
+    SearchRequestBuilder(this, url)
 
 /**
  * A builder for creating and sending requests to search for issues and pull requests
@@ -199,14 +200,14 @@ private fun HttpClient.search(url: String): GitHubSearchRequest =
  * Searching for mentions using [mentions:username](https://shorturl.at/zQzGL) is insufficient,
  * as it only captures mentions in issue comments, missing those in pull request reviews
  * and review comments. Instead, all issues and pull requests where the user was involved
- * are retrieved. Among them, mentions will then need to be manually selected.
+ * are retrieved. Among them, mentions will then need to be selected.
  *
  * @property client The HTTP client on behalf of which requests is made.
  * @property url The GitHub REST API search endpoint.
  * @see <a href="https://shorturl.at/6z3UB">
  *     Search by a user that's involved in an issue or pull request</a>
  */
-private class GitHubSearchRequest(private val client: HttpClient, private val url: String) {
+private class SearchRequestBuilder(private val client: HttpClient, private val url: String) {
     /**
      * The type of the searched item.
      */
@@ -231,7 +232,7 @@ private class GitHubSearchRequest(private val client: HttpClient, private val ur
     /**
      * Sets the type of the searched item.
      */
-    fun by(itemType: ItemType): GitHubSearchRequest {
+    fun by(itemType: ItemType): SearchRequestBuilder {
         this.itemType = itemType
         return this
     }
@@ -240,7 +241,7 @@ private class GitHubSearchRequest(private val client: HttpClient, private val ur
      * Sets the time after which GitHub items containing the searched mentions
      * should have been updated.
      */
-    fun by(updatedAfter: Timestamp): GitHubSearchRequest {
+    fun by(updatedAfter: Timestamp): SearchRequestBuilder {
         this.updatedAfter = updatedAfter
         return this
     }
@@ -248,7 +249,7 @@ private class GitHubSearchRequest(private val client: HttpClient, private val ur
     /**
      * Sets the user authentication token on GitHub
      */
-    fun with(token: PersonalAccessToken): GitHubSearchRequest {
+    fun with(token: PersonalAccessToken): SearchRequestBuilder {
         this.token = token
         return this
     }
@@ -256,7 +257,7 @@ private class GitHubSearchRequest(private val client: HttpClient, private val ur
     /**
      * Sets the page number of the results to fetch.
      */
-    fun onPage(page: Int): GitHubSearchRequest {
+    fun onPage(page: Int): SearchRequestBuilder {
         this.page = page
         return this
     }
@@ -296,8 +297,8 @@ private class GitHubSearchRequest(private val client: HttpClient, private val ur
  * Creates a builder for request to obtain mentions on a specific issue or pull request.
  */
 private fun HttpClient.findMentionsOn(repo: Repo, number: Int, itemType: ItemType):
-        MentionsInIssueOrPullRequests =
-    MentionsInIssueOrPullRequests(this, repo, number, itemType)
+        MentionsOnIssueOrPullRequestsBuilder =
+    MentionsOnIssueOrPullRequestsBuilder(this, repo, number, itemType)
 
 /**
  * A builder for creating and sending request to obtain mentions
@@ -311,7 +312,7 @@ private fun HttpClient.findMentionsOn(repo: Repo, number: Int, itemType: ItemTyp
  * @property number The number of this issue or pull request in the repository.
  * @property itemType The GitHub item type.
  */
-private class MentionsInIssueOrPullRequests(
+private class MentionsOnIssueOrPullRequestsBuilder(
     private val client: HttpClient,
     private val repo: Repo,
     private val number: Int,
@@ -338,7 +339,7 @@ private class MentionsInIssueOrPullRequests(
     /**
      * Sets the name of the user whose mentions are to be found.
      */
-    fun of(user: Username): MentionsInIssueOrPullRequests {
+    fun of(user: Username): MentionsOnIssueOrPullRequestsBuilder {
         this.user = user
         return this
     }
@@ -346,7 +347,7 @@ private class MentionsInIssueOrPullRequests(
     /**
      * Sets the user authentication token on GitHub.
      */
-    fun with(token: PersonalAccessToken): MentionsInIssueOrPullRequests {
+    fun with(token: PersonalAccessToken): MentionsOnIssueOrPullRequestsBuilder {
         this.token = token
         return this
     }
@@ -354,7 +355,7 @@ private class MentionsInIssueOrPullRequests(
     /**
      * Sets the string to be used as the title for the found mentions.
      */
-    fun setTitle(title: String): MentionsInIssueOrPullRequests {
+    fun setTitle(title: String): MentionsOnIssueOrPullRequestsBuilder {
         this.title = title
         return this
     }

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/RemoteGitHubSearch.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/RemoteGitHubSearch.kt
@@ -43,8 +43,8 @@ import io.spine.examples.pingh.github.Username
 import io.spine.examples.pingh.github.from
 import io.spine.examples.pingh.github.repo
 import io.spine.examples.pingh.github.rest.CommentsResponse
-import io.spine.examples.pingh.github.rest.IssuesAndPullRequestsSearchResult
-import io.spine.examples.pingh.github.rest.ReviewResponse
+import io.spine.examples.pingh.github.rest.IssuesAndPullRequestsSearchResponse
+import io.spine.examples.pingh.github.rest.ReviewsResponse
 import io.spine.examples.pingh.github.tag
 import kotlin.jvm.Throws
 import kotlinx.coroutines.runBlocking
@@ -130,7 +130,7 @@ public class RemoteGitHubSearch(engine: HttpClientEngine) : GitHubSearch {
         token: PersonalAccessToken,
         updatedAfter: Timestamp,
         itemType: ItemType
-    ): IssuesAndPullRequestsSearchResult =
+    ): IssuesAndPullRequestsSearchResponse =
         runBlocking {
             val response = client
                 .search("https://api.github.com/search/issues")
@@ -142,7 +142,7 @@ public class RemoteGitHubSearch(engine: HttpClientEngine) : GitHubSearch {
             if (response.status != HttpStatusCode.OK) {
                 throw CannotObtainMentionsException(response.status.value)
             }
-            IssuesAndPullRequestsSearchResult::class.parseJson(response.body())
+            IssuesAndPullRequestsSearchResponse::class.parseJson(response.body())
         }
 }
 
@@ -335,7 +335,7 @@ private class MentionsInIssueOrPullRequests(
      */
     @Throws(CannotObtainMentionsException::class)
     private fun reviews(): Set<Mention> =
-        obtainByUrl(reviewsUrl, ReviewResponse::class::parseJson)
+        obtainByUrl(reviewsUrl, ReviewsResponse::class::parseJson)
             .itemList
             .filter { comment -> comment.body.contains(user!!.tag()) }
             .map { comment -> Mention::class.from(comment, repo.name) }

--- a/mentions/src/test/kotlin/io/spine/examples/pingh/mentions/given/RemoteGitHubSearchSpecEnv.kt
+++ b/mentions/src/test/kotlin/io/spine/examples/pingh/mentions/given/RemoteGitHubSearchSpecEnv.kt
@@ -61,7 +61,10 @@ internal fun mockEngineThatContainsMentions(token: PersonalAccessToken): HttpCli
             }
         }
 
-        if (request.url.pathSegments.size == 7 && request.url.pathSegments[6] == "comments") {
+        if (request.url.pathSegments.size == 7 &&
+            request.url.pathSegments[4] == "issues" &&
+            request.url.pathSegments[6] == "comments"
+        ) {
             if (request.url.pathSegments[5] == "3") {
                 val body = loadJson("comments-under-pr-response.json")
                 return@MockEngine respond(body)
@@ -72,6 +75,23 @@ internal fun mockEngineThatContainsMentions(token: PersonalAccessToken): HttpCli
             }
         }
 
+        if (request.url.pathSegments.size == 7 &&
+            request.url.pathSegments[4] == "pulls" &&
+            request.url.pathSegments[6] == "comments"
+        ) {
+            val body = loadJson("review-comments-response.json")
+            return@MockEngine respond(body)
+        }
+
+        if (request.url.pathSegments.size == 7 &&
+            request.url.pathSegments[4] == "pulls" &&
+            request.url.pathSegments[6] == "reviews"
+        ) {
+            val body = loadJson("reviews-response.json")
+            return@MockEngine respond(body)
+        }
+
+        println(request.url)
         fail("Unexpected request.")
     }
 
@@ -83,14 +103,14 @@ internal fun expectedMentions(): Set<Mention> =
         Mention.newBuilder()
             .setId("IC_kwDOL2L5hc5-0lTv")
             .setAuthor("armiol", "https://avatars.githubusercontent.com/u/82468?v=4")
-            .setTitle("Request updates for assigned issues without activity")
+            .setTitle("Comment on Request updates for assigned issues without activity")
             .setWhenMentioned("2024-05-23T17:38:40Z")
             .setUrl("https://github.com/spine-examples/Pingh/pull/8#issuecomment-2127713519")
             .vBuild(),
         Mention.newBuilder()
             .setId("IC_kwDOL2L5hc5-0lTv")
             .setAuthor("armiol", "https://avatars.githubusercontent.com/u/82468?v=4")
-            .setTitle("Implement user session flow")
+            .setTitle("Comment on Implement user session flow")
             .setWhenMentioned("2024-05-23T17:38:40Z")
             .setUrl("https://github.com/spine-examples/Pingh/pull/8#issuecomment-2127713519")
             .vBuild(),
@@ -100,6 +120,27 @@ internal fun expectedMentions(): Set<Mention> =
             .setTitle("Implement user session flow")
             .setWhenMentioned("2024-05-14T12:12:02Z")
             .setUrl("https://github.com/spine-examples/Pingh/pull/3")
+            .vBuild(),
+        Mention.newBuilder()
+            .setId("PRRC_kwDOL2L5hc5fXf9M")
+            .setAuthor("armiol", "https://avatars.githubusercontent.com/u/82468?v=4")
+            .setTitle("Comment on Implement user session flow")
+            .setWhenMentioned("2024-05-14T13:04:02Z")
+            .setUrl("https://github.com/spine-examples/Pingh/pull/3#discussion_r1599995724")
+            .vBuild(),
+        Mention.newBuilder()
+            .setId("PRR_kwDOL2L5hc56gXMN")
+            .setAuthor("armiol", "https://avatars.githubusercontent.com/u/82468?v=4")
+            .setTitle("Review of Implement user session flow")
+            .setWhenMentioned("2024-05-14T14:56:11Z")
+            .setUrl("https://github.com/spine-examples/Pingh/pull/3#pullrequestreview-2055303949")
+            .vBuild(),
+        Mention.newBuilder()
+            .setId("PRR_kwDOL2L5hc56zimz")
+            .setAuthor("armiol", "https://avatars.githubusercontent.com/u/82468?v=4")
+            .setTitle("Review of Implement user session flow")
+            .setWhenMentioned("2024-05-16T10:35:04Z")
+            .setUrl("https://github.com/spine-examples/Pingh/pull/3#pullrequestreview-2060331443")
             .vBuild(),
     )
 

--- a/testutil-mentions/src/main/kotlin/io/spine/examples/pingh/testing/mentions/given/PredefinedMentionsSet.kt
+++ b/testutil-mentions/src/main/kotlin/io/spine/examples/pingh/testing/mentions/given/PredefinedMentionsSet.kt
@@ -27,7 +27,7 @@
 package io.spine.examples.pingh.testing.mentions.given
 
 import io.spine.examples.pingh.github.Mention
-import io.spine.examples.pingh.github.fromFragment
+import io.spine.examples.pingh.github.from
 import io.spine.examples.pingh.github.rest.CommentsResponse
 import io.spine.examples.pingh.github.rest.IssuesAndPullRequestsSearchResult
 import io.spine.examples.pingh.mentions.parseJson
@@ -52,7 +52,7 @@ private fun loadMentionsInPr(): Set<Mention> {
     val json = jsonFile.readText(Charsets.UTF_8)
     return IssuesAndPullRequestsSearchResult::class.parseJson(json)
         .itemList
-        .map { fragment -> Mention::class.fromFragment(fragment) }
+        .map { fragment -> Mention::class.from(fragment) }
         .toSet()
 }
 
@@ -72,6 +72,6 @@ private fun loadMentionsInCommentsUnderPr(): Set<Mention> {
     // is just the value of the `item` field.
     return CommentsResponse::class.parseJson("{ item: $json }")
         .itemList
-        .map { fragment -> Mention::class.fromFragment(fragment, "Comment") }
+        .map { fragment -> Mention::class.from(fragment, "Comment") }
         .toSet()
 }

--- a/testutil-mentions/src/main/kotlin/io/spine/examples/pingh/testing/mentions/given/PredefinedMentionsSet.kt
+++ b/testutil-mentions/src/main/kotlin/io/spine/examples/pingh/testing/mentions/given/PredefinedMentionsSet.kt
@@ -29,7 +29,7 @@ package io.spine.examples.pingh.testing.mentions.given
 import io.spine.examples.pingh.github.Mention
 import io.spine.examples.pingh.github.from
 import io.spine.examples.pingh.github.rest.CommentsResponse
-import io.spine.examples.pingh.github.rest.IssuesAndPullRequestsSearchResult
+import io.spine.examples.pingh.github.rest.IssuesAndPullRequestsSearchResponse
 import io.spine.examples.pingh.mentions.parseJson
 
 /**
@@ -50,7 +50,7 @@ private fun loadMentionsInPr(): Set<Mention> {
         .getResource("/github-responses/prs-search-response.json")
     checkNotNull(jsonFile)
     val json = jsonFile.readText(Charsets.UTF_8)
-    return IssuesAndPullRequestsSearchResult::class.parseJson(json)
+    return IssuesAndPullRequestsSearchResponse::class.parseJson(json)
         .itemList
         .map { fragment -> Mention::class.from(fragment) }
         .toSet()

--- a/testutil-mentions/src/main/resources/github-responses/review-comments-response.json
+++ b/testutil-mentions/src/main/resources/github-responses/review-comments-response.json
@@ -1,0 +1,274 @@
+[
+  {
+    "url": "https://api.github.com/repos/spine-examples/Pingh/pulls/comments/1599995724",
+    "pull_request_review_id": 2055303949,
+    "id": 1599995724,
+    "node_id": "PRRC_kwDOL2L5hc5fXf9M",
+    "diff_hunk": "@@ -0,0 +1,55 @@\n+/*\n+ * Copyright 2024, TeamDev. All rights reserved.\n+ *\n+ * Licensed under the Apache License, Version 2.0 (the \"License\");\n+ * you may not use this file except in compliance with the License.\n+ * You may obtain a copy of the License at\n+ *\n+ * http://www.apache.org/licenses/LICENSE-2.0\n+ *\n+ * Redistribution and use in source and/or binary forms, with or without\n+ * modification, must retain the above copyright notice and the following\n+ * disclaimer.\n+ *\n+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n+ * \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\n+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\n+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\n+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\n+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\n+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\n+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n+ */\n+\n+package io.spine.examples.pingh.sessions\n+\n+import io.spine.server.BoundedContext\n+import io.spine.server.BoundedContextBuilder\n+\n+/**\n+ * Configurator that customizes the session bounded context",
+    "path": "sessions/src/main/kotlin/io/spine/examples/pingh/sessions/SessionsContext.kt",
+    "commit_id": "289c072a3976a8fb505d75d38cbeef40173604e1",
+    "original_commit_id": "514e00aadad6df1063b8098fcec74a694034a12c",
+    "user": {
+      "login": "armiol",
+      "id": 82468,
+      "node_id": "MDQ6VXNlcjgyNDY4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/82468?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/armiol",
+      "html_url": "https://github.com/armiol",
+      "followers_url": "https://api.github.com/users/armiol/followers",
+      "following_url": "https://api.github.com/users/armiol/following{/other_user}",
+      "gists_url": "https://api.github.com/users/armiol/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/armiol/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/armiol/subscriptions",
+      "organizations_url": "https://api.github.com/users/armiol/orgs",
+      "repos_url": "https://api.github.com/users/armiol/repos",
+      "events_url": "https://api.github.com/users/armiol/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/armiol/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "@MykytaPimonovTD Please do study other examples in this organization.\r\n\r\nFor instance, a similar type is declared [here](https://github.com/spine-examples/kanban/blob/master/server/src/main/java/io/spine/examples/kanban/server/KanbanContext.java).",
+    "created_at": "2024-05-14T13:04:02Z",
+    "updated_at": "2024-05-14T14:56:11Z",
+    "html_url": "https://github.com/spine-examples/Pingh/pull/3#discussion_r1599995724",
+    "pull_request_url": "https://api.github.com/repos/spine-examples/Pingh/pulls/3",
+    "author_association": "CONTRIBUTOR",
+    "_links": {
+      "self": {
+        "href": "https://api.github.com/repos/spine-examples/Pingh/pulls/comments/1599995724"
+      },
+      "html": {
+        "href": "https://github.com/spine-examples/Pingh/pull/3#discussion_r1599995724"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/spine-examples/Pingh/pulls/3"
+      }
+    },
+    "reactions": {
+      "url": "https://api.github.com/repos/spine-examples/Pingh/pulls/comments/1599995724/reactions",
+      "total_count": 0,
+      "+1": 0,
+      "-1": 0,
+      "laugh": 0,
+      "hooray": 0,
+      "confused": 0,
+      "heart": 0,
+      "rocket": 0,
+      "eyes": 0
+    },
+    "start_line": null,
+    "original_start_line": null,
+    "start_side": null,
+    "line": null,
+    "original_line": 33,
+    "side": "RIGHT",
+    "original_position": 33,
+    "position": null,
+    "subject_type": "line"
+  },
+  {
+    "url": "https://api.github.com/repos/spine-examples/Pingh/pulls/comments/1603091135",
+    "pull_request_review_id": 2060331443,
+    "id": 1603091135,
+    "node_id": "PRRC_kwDOL2L5hc5fjTq_",
+    "diff_hunk": "@@ -0,0 +1,148 @@\n+/*\n+ * Copyright 2024, TeamDev. All rights reserved.\n+ *\n+ * Licensed under the Apache License, Version 2.0 (the \"License\");\n+ * you may not use this file except in compliance with the License.\n+ * You may obtain a copy of the License at\n+ *\n+ * http://www.apache.org/licenses/LICENSE-2.0\n+ *\n+ * Redistribution and use in source and/or binary forms, with or without\n+ * modification, must retain the above copyright notice and the following\n+ * disclaimer.\n+ *\n+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n+ * \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\n+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\n+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\n+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\n+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\n+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\n+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n+ */\n+\n+package io.spine.examples.pingh.sessions\n+\n+import io.kotest.matchers.shouldBe\n+import io.spine.base.EventMessage\n+import io.spine.examples.pingh.sessions.event.UserLoggedIn\n+import io.spine.examples.pingh.sessions.event.UserLoggedOut\n+import io.spine.examples.pingh.sessions.given.*\n+import io.spine.protobuf.AnyPacker\n+import io.spine.server.BoundedContextBuilder\n+import io.spine.testing.server.EventSubject\n+import io.spine.testing.server.blackbox.ContextAwareTest\n+import org.junit.jupiter.api.BeforeEach\n+import org.junit.jupiter.api.DisplayName\n+import org.junit.jupiter.api.Nested\n+import org.junit.jupiter.api.Test\n+\n+@DisplayName(\"Sessions Context should\")\n+class SessionsContextSpec : ContextAwareTest() {\n+\n+    override fun contextBuilder(): BoundedContextBuilder =\n+        newBuilder()\n+\n+    @Nested\n+    inner class `handle the 'LogUserIn' command` {",
+    "path": "sessions/src/test/kotlin/io/spine/examples/pingh/sessions/SessionsContextSpec.kt",
+    "commit_id": "289c072a3976a8fb505d75d38cbeef40173604e1",
+    "original_commit_id": "0ca99e4a53d72cd562508a60074e8900324f9c4d",
+    "user": {
+      "login": "armiol",
+      "id": 82468,
+      "node_id": "MDQ6VXNlcjgyNDY4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/82468?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/armiol",
+      "html_url": "https://github.com/armiol",
+      "followers_url": "https://api.github.com/users/armiol/followers",
+      "following_url": "https://api.github.com/users/armiol/following{/other_user}",
+      "gists_url": "https://api.github.com/users/armiol/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/armiol/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/armiol/subscriptions",
+      "organizations_url": "https://api.github.com/users/armiol/orgs",
+      "repos_url": "https://api.github.com/users/armiol/repos",
+      "events_url": "https://api.github.com/users/armiol/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/armiol/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "I think we can safely omit \"the\" here and in the following method names.",
+    "created_at": "2024-05-16T10:28:33Z",
+    "updated_at": "2024-05-16T10:35:05Z",
+    "html_url": "https://github.com/spine-examples/Pingh/pull/3#discussion_r1603091135",
+    "pull_request_url": "https://api.github.com/repos/spine-examples/Pingh/pulls/3",
+    "author_association": "CONTRIBUTOR",
+    "_links": {
+      "self": {
+        "href": "https://api.github.com/repos/spine-examples/Pingh/pulls/comments/1603091135"
+      },
+      "html": {
+        "href": "https://github.com/spine-examples/Pingh/pull/3#discussion_r1603091135"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/spine-examples/Pingh/pulls/3"
+      }
+    },
+    "reactions": {
+      "url": "https://api.github.com/repos/spine-examples/Pingh/pulls/comments/1603091135/reactions",
+      "total_count": 0,
+      "+1": 0,
+      "-1": 0,
+      "laugh": 0,
+      "hooray": 0,
+      "confused": 0,
+      "heart": 0,
+      "rocket": 0,
+      "eyes": 0
+    },
+    "start_line": null,
+    "original_start_line": null,
+    "start_side": null,
+    "line": null,
+    "original_line": 50,
+    "side": "RIGHT",
+    "original_position": 50,
+    "position": null,
+    "subject_type": "line"
+  },
+  {
+    "url": "https://api.github.com/repos/spine-examples/Pingh/pulls/comments/1603093658",
+    "pull_request_review_id": 2060331443,
+    "id": 1603093658,
+    "node_id": "PRRC_kwDOL2L5hc5fjUSa",
+    "diff_hunk": "@@ -0,0 +1,148 @@\n+/*\n+ * Copyright 2024, TeamDev. All rights reserved.\n+ *\n+ * Licensed under the Apache License, Version 2.0 (the \"License\");\n+ * you may not use this file except in compliance with the License.\n+ * You may obtain a copy of the License at\n+ *\n+ * http://www.apache.org/licenses/LICENSE-2.0\n+ *\n+ * Redistribution and use in source and/or binary forms, with or without\n+ * modification, must retain the above copyright notice and the following\n+ * disclaimer.\n+ *\n+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n+ * \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\n+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\n+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\n+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\n+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\n+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\n+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n+ */\n+\n+package io.spine.examples.pingh.sessions\n+\n+import io.kotest.matchers.shouldBe\n+import io.spine.base.EventMessage\n+import io.spine.examples.pingh.sessions.event.UserLoggedIn\n+import io.spine.examples.pingh.sessions.event.UserLoggedOut\n+import io.spine.examples.pingh.sessions.given.*\n+import io.spine.protobuf.AnyPacker\n+import io.spine.server.BoundedContextBuilder\n+import io.spine.testing.server.EventSubject\n+import io.spine.testing.server.blackbox.ContextAwareTest\n+import org.junit.jupiter.api.BeforeEach\n+import org.junit.jupiter.api.DisplayName\n+import org.junit.jupiter.api.Nested\n+import org.junit.jupiter.api.Test\n+\n+@DisplayName(\"Sessions Context should\")\n+class SessionsContextSpec : ContextAwareTest() {\n+\n+    override fun contextBuilder(): BoundedContextBuilder =\n+        newBuilder()\n+\n+    @Nested\n+    inner class `handle the 'LogUserIn' command` {\n+\n+        private lateinit var session: SessionId\n+\n+        @BeforeEach\n+        fun sendCommand() {\n+            session = createSession()\n+            val command = logUserIn(session)\n+            context().receivesCommand(command)\n+        }\n+\n+        @Test\n+        fun `emit 'UserLoggedIn' event`() {\n+            val expected = with(UserLoggedIn.newBuilder()) {\n+                id = session\n+                build()\n+            }\n+            val events = assertEvents(UserLoggedIn::class.java)\n+            events.hasSize(1)\n+            events.message(0)\n+                .comparingExpectedFieldsOnly()\n+                .isEqualTo(expected)\n+        }\n+\n+        @Test\n+        fun `update the 'UserSession' entity`() {\n+            val expected = userSession(session)\n+            context().assertState(session, expected)\n+        }\n+    }\n+\n+    @Nested\n+    inner class `handle the 'LogUserOut' command` {\n+\n+        private lateinit var session: SessionId\n+\n+        @BeforeEach\n+        fun sendCommand() {\n+            session = createSession()\n+            context().receivesCommand(logUserIn(session))\n+            context().receivesCommand(logUserOut(session))\n+        }\n+\n+        @Test\n+        fun `emit 'UserLoggedOut' event`() {\n+            val expected = with(UserLoggedOut.newBuilder()) {\n+                id = session\n+                vBuild()\n+            }\n+            val eventSubject = assertEvents(UserLoggedOut::class.java)\n+            eventSubject.hasSize(1)\n+            val event = eventSubject.actual()[0]\n+            val message = AnyPacker.unpack(event.message, UserLoggedOut::class.java)",
+    "path": "sessions/src/test/kotlin/io/spine/examples/pingh/sessions/SessionsContextSpec.kt",
+    "commit_id": "289c072a3976a8fb505d75d38cbeef40173604e1",
+    "original_commit_id": "0ca99e4a53d72cd562508a60074e8900324f9c4d",
+    "user": {
+      "login": "armiol",
+      "id": 82468,
+      "node_id": "MDQ6VXNlcjgyNDY4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/82468?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/armiol",
+      "html_url": "https://github.com/armiol",
+      "followers_url": "https://api.github.com/users/armiol/followers",
+      "following_url": "https://api.github.com/users/armiol/following{/other_user}",
+      "gists_url": "https://api.github.com/users/armiol/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/armiol/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/armiol/subscriptions",
+      "organizations_url": "https://api.github.com/users/armiol/orgs",
+      "repos_url": "https://api.github.com/users/armiol/repos",
+      "events_url": "https://api.github.com/users/armiol/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/armiol/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "I think this whole piece can be simplified. See [this API call](https://github.com/SpineEventEngine/core-java/blob/1.x-dev/testutil-server/src/main/java/io/spine/testing/server/blackbox/BlackBoxContext.java#L678).",
+    "created_at": "2024-05-16T10:30:38Z",
+    "updated_at": "2024-05-16T10:35:05Z",
+    "html_url": "https://github.com/spine-examples/Pingh/pull/3#discussion_r1603093658",
+    "pull_request_url": "https://api.github.com/repos/spine-examples/Pingh/pulls/3",
+    "author_association": "CONTRIBUTOR",
+    "_links": {
+      "self": {
+        "href": "https://api.github.com/repos/spine-examples/Pingh/pulls/comments/1603093658"
+      },
+      "html": {
+        "href": "https://github.com/spine-examples/Pingh/pull/3#discussion_r1603093658"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/spine-examples/Pingh/pulls/3"
+      }
+    },
+    "reactions": {
+      "url": "https://api.github.com/repos/spine-examples/Pingh/pulls/comments/1603093658/reactions",
+      "total_count": 0,
+      "+1": 0,
+      "-1": 0,
+      "laugh": 0,
+      "hooray": 0,
+      "confused": 0,
+      "heart": 0,
+      "rocket": 0,
+      "eyes": 0
+    },
+    "start_line": null,
+    "original_start_line": null,
+    "start_side": null,
+    "line": null,
+    "original_line": 102,
+    "side": "RIGHT",
+    "original_position": 102,
+    "position": null,
+    "subject_type": "line"
+  },
+  {
+    "url": "https://api.github.com/repos/spine-examples/Pingh/pulls/comments/1603094380",
+    "pull_request_review_id": 2060331443,
+    "id": 1603094380,
+    "node_id": "PRRC_kwDOL2L5hc5fjUds",
+    "diff_hunk": "@@ -0,0 +1,148 @@\n+/*\n+ * Copyright 2024, TeamDev. All rights reserved.\n+ *\n+ * Licensed under the Apache License, Version 2.0 (the \"License\");\n+ * you may not use this file except in compliance with the License.\n+ * You may obtain a copy of the License at\n+ *\n+ * http://www.apache.org/licenses/LICENSE-2.0\n+ *\n+ * Redistribution and use in source and/or binary forms, with or without\n+ * modification, must retain the above copyright notice and the following\n+ * disclaimer.\n+ *\n+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n+ * \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\n+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\n+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\n+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\n+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\n+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\n+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n+ */\n+\n+package io.spine.examples.pingh.sessions\n+\n+import io.kotest.matchers.shouldBe\n+import io.spine.base.EventMessage\n+import io.spine.examples.pingh.sessions.event.UserLoggedIn\n+import io.spine.examples.pingh.sessions.event.UserLoggedOut\n+import io.spine.examples.pingh.sessions.given.*\n+import io.spine.protobuf.AnyPacker\n+import io.spine.server.BoundedContextBuilder\n+import io.spine.testing.server.EventSubject\n+import io.spine.testing.server.blackbox.ContextAwareTest\n+import org.junit.jupiter.api.BeforeEach\n+import org.junit.jupiter.api.DisplayName\n+import org.junit.jupiter.api.Nested\n+import org.junit.jupiter.api.Test\n+\n+@DisplayName(\"Sessions Context should\")\n+class SessionsContextSpec : ContextAwareTest() {\n+\n+    override fun contextBuilder(): BoundedContextBuilder =\n+        newBuilder()\n+\n+    @Nested\n+    inner class `handle the 'LogUserIn' command` {\n+\n+        private lateinit var session: SessionId\n+\n+        @BeforeEach\n+        fun sendCommand() {\n+            session = createSession()\n+            val command = logUserIn(session)\n+            context().receivesCommand(command)\n+        }\n+\n+        @Test\n+        fun `emit 'UserLoggedIn' event`() {\n+            val expected = with(UserLoggedIn.newBuilder()) {\n+                id = session\n+                build()\n+            }\n+            val events = assertEvents(UserLoggedIn::class.java)\n+            events.hasSize(1)\n+            events.message(0)\n+                .comparingExpectedFieldsOnly()\n+                .isEqualTo(expected)\n+        }\n+\n+        @Test\n+        fun `update the 'UserSession' entity`() {\n+            val expected = userSession(session)\n+            context().assertState(session, expected)\n+        }\n+    }\n+\n+    @Nested\n+    inner class `handle the 'LogUserOut' command` {\n+\n+        private lateinit var session: SessionId\n+\n+        @BeforeEach\n+        fun sendCommand() {\n+            session = createSession()\n+            context().receivesCommand(logUserIn(session))\n+            context().receivesCommand(logUserOut(session))",
+    "path": "sessions/src/test/kotlin/io/spine/examples/pingh/sessions/SessionsContextSpec.kt",
+    "commit_id": "289c072a3976a8fb505d75d38cbeef40173604e1",
+    "original_commit_id": "0ca99e4a53d72cd562508a60074e8900324f9c4d",
+    "user": {
+      "login": "armiol",
+      "id": 82468,
+      "node_id": "MDQ6VXNlcjgyNDY4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/82468?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/armiol",
+      "html_url": "https://github.com/armiol",
+      "followers_url": "https://api.github.com/users/armiol/followers",
+      "following_url": "https://api.github.com/users/armiol/following{/other_user}",
+      "gists_url": "https://api.github.com/users/armiol/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/armiol/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/armiol/subscriptions",
+      "organizations_url": "https://api.github.com/users/armiol/orgs",
+      "repos_url": "https://api.github.com/users/armiol/repos",
+      "events_url": "https://api.github.com/users/armiol/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/armiol/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "Instead of calling `context()` twice, you can chain `.receivesCommand(..)` calls.\r\n\r\nSame below.",
+    "created_at": "2024-05-16T10:31:12Z",
+    "updated_at": "2024-05-16T10:35:05Z",
+    "html_url": "https://github.com/spine-examples/Pingh/pull/3#discussion_r1603094380",
+    "pull_request_url": "https://api.github.com/repos/spine-examples/Pingh/pulls/3",
+    "author_association": "CONTRIBUTOR",
+    "_links": {
+      "self": {
+        "href": "https://api.github.com/repos/spine-examples/Pingh/pulls/comments/1603094380"
+      },
+      "html": {
+        "href": "https://github.com/spine-examples/Pingh/pull/3#discussion_r1603094380"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/spine-examples/Pingh/pulls/3"
+      }
+    },
+    "reactions": {
+      "url": "https://api.github.com/repos/spine-examples/Pingh/pulls/comments/1603094380/reactions",
+      "total_count": 0,
+      "+1": 0,
+      "-1": 0,
+      "laugh": 0,
+      "hooray": 0,
+      "confused": 0,
+      "heart": 0,
+      "rocket": 0,
+      "eyes": 0
+    },
+    "start_line": null,
+    "original_start_line": null,
+    "start_side": null,
+    "line": null,
+    "original_line": 90,
+    "side": "RIGHT",
+    "original_position": 90,
+    "position": null,
+    "subject_type": "line"
+  }
+]

--- a/testutil-mentions/src/main/resources/github-responses/reviews-response.json
+++ b/testutil-mentions/src/main/resources/github-responses/reviews-response.json
@@ -1,0 +1,80 @@
+[
+  {
+    "id": 2055303949,
+    "node_id": "PRR_kwDOL2L5hc56gXMN",
+    "user": {
+      "login": "armiol",
+      "id": 82468,
+      "node_id": "MDQ6VXNlcjgyNDY4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/82468?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/armiol",
+      "html_url": "https://github.com/armiol",
+      "followers_url": "https://api.github.com/users/armiol/followers",
+      "following_url": "https://api.github.com/users/armiol/following{/other_user}",
+      "gists_url": "https://api.github.com/users/armiol/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/armiol/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/armiol/subscriptions",
+      "organizations_url": "https://api.github.com/users/armiol/orgs",
+      "repos_url": "https://api.github.com/users/armiol/repos",
+      "events_url": "https://api.github.com/users/armiol/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/armiol/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "@MykytaPimonovTD after our vocal discussion, I am now requesting changes to this PR.\r\nThis is needed so that you could re-request a review once you make the adjustments we discussed.",
+    "state": "CHANGES_REQUESTED",
+    "html_url": "https://github.com/spine-examples/Pingh/pull/3#pullrequestreview-2055303949",
+    "pull_request_url": "https://api.github.com/repos/spine-examples/Pingh/pulls/3",
+    "author_association": "CONTRIBUTOR",
+    "_links": {
+      "html": {
+        "href": "https://github.com/spine-examples/Pingh/pull/3#pullrequestreview-2055303949"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/spine-examples/Pingh/pulls/3"
+      }
+    },
+    "submitted_at": "2024-05-14T14:56:11Z",
+    "commit_id": "e12dc42cc9ac33931bb2f64deb278447a7560934"
+  },
+  {
+    "id": 2060331443,
+    "node_id": "PRR_kwDOL2L5hc56zimz",
+    "user": {
+      "login": "armiol",
+      "id": 82468,
+      "node_id": "MDQ6VXNlcjgyNDY4",
+      "avatar_url": "https://avatars.githubusercontent.com/u/82468?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/armiol",
+      "html_url": "https://github.com/armiol",
+      "followers_url": "https://api.github.com/users/armiol/followers",
+      "following_url": "https://api.github.com/users/armiol/following{/other_user}",
+      "gists_url": "https://api.github.com/users/armiol/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/armiol/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/armiol/subscriptions",
+      "organizations_url": "https://api.github.com/users/armiol/orgs",
+      "repos_url": "https://api.github.com/users/armiol/repos",
+      "events_url": "https://api.github.com/users/armiol/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/armiol/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "@MykytaPimonovTD much better.\r\n\r\nPlease see my comments.",
+    "state": "CHANGES_REQUESTED",
+    "html_url": "https://github.com/spine-examples/Pingh/pull/3#pullrequestreview-2060331443",
+    "pull_request_url": "https://api.github.com/repos/spine-examples/Pingh/pulls/3",
+    "author_association": "CONTRIBUTOR",
+    "_links": {
+      "html": {
+        "href": "https://github.com/spine-examples/Pingh/pull/3#pullrequestreview-2060331443"
+      },
+      "pull_request": {
+        "href": "https://api.github.com/repos/spine-examples/Pingh/pulls/3"
+      }
+    },
+    "submitted_at": "2024-05-16T10:35:04Z",
+    "commit_id": "0ca99e4a53d72cd562508a60074e8900324f9c4d"
+  }
+]


### PR DESCRIPTION
A GitHub pull request contains three types of items where a user can be mentioned: issue comments, reviews, and review comments, whereas an issue only has issue comments. The [mentions:user](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests#search-by-mention) filter was used to search for mentions, but it only searched within the bodies of issues and pull requests, along with issue comments. As a result, mentions in reviews and review comments were overlooked.

This changeset resolves this issue by enabling the detection of all user mentions in a pull request.

First, the `mentions:user` filter is replaced with the [involves:user](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests#search-by-a-user-thats-involved-in-an-issue-or-pull-request) filter to find issues and pull requests where the user was involved (as an author, commenter, assignee, or mentioned). After retrieving these items, mentions are extracted from them.

Second, the search for mentions in a pull request now includes review and review comments, in addition to issue comments.

Pagination-aware processing of search request results is also implemented. When making a search request using the GitHub REST API, the maximum number of items returned in a single response is 100. To prevent data loss, the `GitHubSearch` checks whether all items are retrieved, and if not, it makes additional requests.