### PR TITLE
 Move `LoginFlow` stages to separate files

### DIFF
--- a/client/src/main/kotlin/io/spine/examples/pingh/client/EnterUsername.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/EnterUsername.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.pingh.client
+
+import io.spine.examples.pingh.github.Username
+import io.spine.examples.pingh.sessions.SessionId
+import io.spine.examples.pingh.sessions.command.LogUserIn
+import io.spine.examples.pingh.sessions.event.UserCodeReceived
+import io.spine.examples.pingh.sessions.of
+import io.spine.examples.pingh.sessions.withSession
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * A stage of the login flow on which the user enters their GitHub username
+ * and receives a user code in return.
+ *
+ * @property client Enables interaction with the Pingh server.
+ * @property session The information about the current user session.
+ * @property moveToNextStage Switches the current stage to the [VerifyLogin].
+ */
+public class EnterUsername internal constructor(
+    private val client: DesktopClient,
+    private val session: MutableStateFlow<UserSession?>,
+    private val moveToNextStage: () -> Unit
+) : LoginStage<UserCodeReceived>() {
+
+    /**
+     * Starts the GitHub login process and requests `UserCode`.
+     *
+     * @param username The username of the user logging in.
+     * @param onSuccess Called when the user code is successfully received.
+     */
+    public fun requestUserCode(
+        username: Username,
+        onSuccess: (event: UserCodeReceived) -> Unit = {}
+    ) {
+        val command = LogUserIn::class.withSession(
+            SessionId::class.of(username)
+        )
+        client.observeEvent(command.id, UserCodeReceived::class) { event ->
+            session.value = UserSession(event.id)
+            result = event
+            moveToNextStage()
+            onSuccess(event)
+        }
+        client.send(command)
+    }
+}

--- a/client/src/main/kotlin/io/spine/examples/pingh/client/LoginFailed.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/LoginFailed.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.pingh.client
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * A stage in the login flow that indicates a failure in the process.
+ *
+ * Possible reasons for failure include:
+ *
+ * 1. The user is not a member of an authorized organization.
+ * 2. The username obtained in [EnterUsername] stage differs from the username
+ * of the account used to complete [VerifyLogin] stage.
+ *
+ * @property moveToNextStage Switches the current stage to the [EnterUsername].
+ * @param cause The reason for the login failure.
+ */
+public class LoginFailed internal constructor(
+    private val moveToNextStage: () -> Unit,
+    cause: String
+) : LoginStage<Unit>() {
+
+    /**
+     * The error message from the login process.
+     */
+    public val errorMessage: StateFlow<String> = MutableStateFlow(cause)
+
+    /**
+     * Starts the login process from the beginning.
+     */
+    public fun restartLogin() {
+        moveToNextStage()
+    }
+}

--- a/client/src/main/kotlin/io/spine/examples/pingh/client/LoginFlow.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/LoginFlow.kt
@@ -94,7 +94,7 @@ public class LoginFlow internal constructor(
         when (stage.value) {
             is EnterUsername -> {
                 checkNotNull(stage.value.result) {
-                    "The `UserCodeReceived` event was not specified as the result " +
+                    "The `UserCodeReceived` event is not specified as the result " +
                             "of the `EnterUsername` stage."
                 }
                 stage.value = VerifyLogin(
@@ -105,7 +105,7 @@ public class LoginFlow internal constructor(
 
             is VerifyLogin -> {
                 checkNotNull(stage.value.result) {
-                    "No error message was specified as the result of the `VerifyLogin` stage."
+                    "No error message is specified as the result of the `VerifyLogin` stage."
                 }
                 stage.value = LoginFailed(::moveToNextStage, stage.value.result as String)
             }

--- a/client/src/main/kotlin/io/spine/examples/pingh/client/LoginFlow.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/LoginFlow.kt
@@ -26,27 +26,26 @@
 
 package io.spine.examples.pingh.client
 
-import com.google.protobuf.Duration
-import io.spine.examples.pingh.github.UserCode
-import io.spine.examples.pingh.github.Username
-import io.spine.examples.pingh.sessions.SessionId
-import io.spine.examples.pingh.sessions.of
-import io.spine.examples.pingh.sessions.withSession
-import io.spine.examples.pingh.sessions.command.LogUserIn
-import io.spine.examples.pingh.sessions.command.VerifyUserLoginToGitHub
 import io.spine.examples.pingh.sessions.event.UserCodeReceived
-import io.spine.examples.pingh.sessions.event.UserIsNotLoggedIntoGitHub
-import io.spine.examples.pingh.sessions.event.UserLoggedIn
-import io.spine.examples.pingh.sessions.rejection.Rejections.NotMemberOfPermittedOrgs
-import io.spine.examples.pingh.sessions.rejection.Rejections.UsernameMismatch
-import io.spine.net.Url
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
+
+/**
+ * Represents a stage in the GitHub login process.
+ *
+ * @param T The type of result produced upon executing this stage.
+ *   If it is `Unit`, it means the stage produces no result.
+ */
+@Suppress("UnnecessaryAbstractClass" /* Avoids creating instances; only for inheritance. */)
+public abstract class LoginStage<T> {
+    /**
+     * The result of executing this stage.
+     *
+     * Used to [move][LoginFlow.moveToNextStage] to the next stage,
+     * must be specified before moving to the next stage.
+     */
+    internal var result: T? = null
+}
 
 /**
  * Describes the login to GitHub via GitHub's device flow.
@@ -54,12 +53,12 @@ import kotlinx.coroutines.launch
  * There are several stages in this process:
  *
  * 1. [EnterUsername]: The user inputs their username to receive a user code.
- * 2. [Verify]: The user enters the user code on GitHub and confirms
+ * 2. [VerifyLogin]: The user enters the user code on GitHub and confirms
  * the login within the Pingh app.
- * 3. [Failed]: The login process failed due to an error that occurred during authentication.
+ * 3. [LoginFailed]: The login process failed due to an error that occurred during authentication.
  *
  * The flow is considered completed whenever the login is successfully
- * [confirmed][Verify.confirm] in the Pingh app.
+ * [confirmed][VerifyLogin.confirm] in the Pingh app.
  *
  * @property client Enables interaction with the Pingh server.
  * @property session The information about the current user session.
@@ -69,278 +68,51 @@ public class LoginFlow internal constructor(
     private val session: MutableStateFlow<UserSession?>
 ) {
     /**
-     * Possible transitions between stages.
-     *
-     * Movement from one stage to another is restricted to specific stages,
-     * and some stages may be final with no further transitions.
-     * Each stage [change][moveToNextStage] verifies if the transition is permissible.
-     */
-    private val possibleTransitions = mapOf(
-        EnterUsername::class to listOf(Verify::class),
-        Verify::class to listOf(Failed::class),
-        Failed::class to listOf(EnterUsername::class),
-    )
-
-    /**
      * Current stage of the GitHub login process.
      */
-    private val stage: MutableStateFlow<Stage> = MutableStateFlow(EnterUsername())
+    private val stage: MutableStateFlow<LoginStage<*>> =
+        MutableStateFlow(EnterUsername(client, session, ::moveToNextStage))
 
     /**
      * Returns the immutable state of the current login stage.
      */
-    public fun currentStage(): StateFlow<Stage> = stage
+    public fun currentStage(): StateFlow<LoginStage<*>> = stage
 
     /**
-     * Switches the current stage to the passed one.
+     * Switches the [current stage][stage] to the next one.
      *
-     * @throws IllegalStateException if the transition of their current [stage]
-     *   to the passed stage is not [allowed][possibleTransitions].
-     */
-    private fun moveToNextStage(stage: Stage) {
-        val current = this.stage.value::class
-        val possibleNext = possibleTransitions.getOrDefault(current, emptyList())
-        val next = stage::class
-        if (!possibleNext.contains(next)) {
-            throw IllegalStateException(
-                "Moving from $current stage to $next stage is not allowed; " +
-                        "only $possibleNext stages is permitted."
-            )
-        }
-        this.stage.value = stage
-    }
-
-    /**
-     * Represents a stage in the GitHub login process.
-     */
-    public interface Stage
-
-    /**
-     * A stage of the login flow on which the user enters their GitHub username
-     * and receives a user code in return.
-     */
-    public inner class EnterUsername internal constructor() : Stage {
-        /**
-         * Starts the GitHub login process and requests `UserCode`.
-         *
-         * @param username The username of the user logging in.
-         * @param onSuccess Called when the user code is successfully received.
-         */
-        public fun requestUserCode(
-            username: Username,
-            onSuccess: (event: UserCodeReceived) -> Unit = {}
-        ) {
-            val command = LogUserIn::class.withSession(
-                SessionId::class.of(username)
-            )
-            client.observeEvent(command.id, UserCodeReceived::class) { event ->
-                session.value = UserSession(event.id)
-                moveToNextStage(Verify(event))
-                onSuccess(event)
-            }
-            client.send(command)
-        }
-    }
-
-    /**
-     * A stage of the login flow on which the user enters the received user code
-     * into GitHub to verify their login.
+     * Some transitions rely on [result][LoginStage.result] from the previous stage
+     * to create a new stage. Ensure previous stage's result is set.
      *
-     * @param event The event received after the user enters their name.
+     * Transition order:
+     *
+     * - From [EnterUsername] stage to [VerifyLogin] stage;
+     * - From `VerifyLogin` stage to [LoginFailed] stage;
+     * - From `LoginFailed` stage back to `EnterUsername` stage.
      */
-    @Suppress("MemberVisibilityCanBePrivate" /* Accessed from `desktop` module. */)
-    public inner class Verify internal constructor(event: UserCodeReceived) : Stage {
-        /**
-         * The code a user needs to enter on GitHub to confirm login to the app.
-         */
-        public val userCode: MutableStateFlow<UserCode> =
-            MutableStateFlow(event.userCode)
-
-        /**
-         * The URL of the GitHub resource, where users will be entering the verification code
-         * in scope of the device login flow.
-         */
-        public val verificationUrl: MutableStateFlow<Url> =
-            MutableStateFlow(event.verificationUrl)
-
-        /**
-         * The minimum duration that must pass before user can make a new access token request.
-         */
-        public val interval: MutableStateFlow<Duration> =
-            MutableStateFlow(event.interval)
-
-        /**
-         * Whether a new token can be asked from the external API.
-         *
-         * The contract of the external API assumes some delay that must pass
-         * before a new token can be requested. Therefore, we should wait for this call
-         * to become available.
-         *
-         * @see [interval]
-         */
-        public val canAskForNewTokens: MutableStateFlow<Boolean> = MutableStateFlow(true)
-
-        /**
-         * The duration after which the [userCode] expires.
-         */
-        public val expiresIn: MutableStateFlow<Duration> =
-            MutableStateFlow(event.expiresIn)
-
-        /**
-         * Whether the user code is expired.
-         *
-         * @see [expiresIn]
-         */
-        public val isUserCodeExpired: MutableStateFlow<Boolean> = MutableStateFlow(false)
-
-        /**
-         * Job that marks a [userCode] as expired after the [time][expiresIn] has passed.
-         */
-        private lateinit var codeExpirationJob: Job
-
-        init {
-            watchForCodeExpiration()
-        }
-
-        /**
-         * Starts a job that will mark the [userCode] as expired when [time][expiresIn] passes.
-         */
-        private fun watchForCodeExpiration() {
-            isUserCodeExpired.value = false
-            codeExpirationJob = invoke(expiresIn.value) {
-                isUserCodeExpired.value = true
-            }
-        }
-
-        /**
-         * Checks whether the user has completed the login on GitHub and entered their user code.
-         *
-         * Rejections during verification cause the process to transition to the [Failed] stage.
-         *
-         * @param onSuccess Called when the login is successfully verified.
-         * @param onFail Called when login verification fails.
-         */
-        public fun confirm(
-            onSuccess: (event: UserLoggedIn) -> Unit = {},
-            onFail: (event: UserIsNotLoggedIntoGitHub) -> Unit = {}
-        ) {
-            val command = VerifyUserLoginToGitHub::class.withSession(session.value!!.id)
-            client.observeEither(
-                EventObserver(command.id, UserLoggedIn::class) { event ->
-                    codeExpirationJob.cancel()
-                    onSuccess(event)
-                },
-                EventObserver(command.id, UserIsNotLoggedIntoGitHub::class) { event ->
-                    preventAskingForNewTokens()
-                    onFail(event)
-                },
-                EventObserver(command.id, UsernameMismatch::class) { rejection ->
-                    codeExpirationJob.cancel()
-                    moveToNextStage(Failed(rejection.cause))
-                },
-                EventObserver(command.id, NotMemberOfPermittedOrgs::class) { rejection ->
-                    codeExpirationJob.cancel()
-                    moveToNextStage(Failed(rejection.cause))
+    private fun moveToNextStage() {
+        when (stage.value) {
+            is EnterUsername -> {
+                checkNotNull(stage.value.result) {
+                    "The `UserCodeReceived` event was not specified as the result " +
+                            "of the `EnterUsername` stage."
                 }
-            )
-            client.send(command)
-        }
-
-        /**
-         * Prevents requests for new tokens during the [interval].
-         */
-        private fun preventAskingForNewTokens() {
-            canAskForNewTokens.value = false
-            invoke(interval.value) {
-                canAskForNewTokens.value = true
+                stage.value = VerifyLogin(
+                    client, session, ::moveToNextStage,
+                    stage.value.result as UserCodeReceived
+                )
             }
-        }
 
-        /**
-         * Requests a new `UserCode` on behalf of the current user.
-         *
-         * Resets the current stage to its initial state by canceling all active tasks
-         * and updating fields values with data from the `UserCodeReceived` event.
-         *
-         * @param onSuccess Called when the user code is successfully received.
-         */
-        public fun requestNewUserCode(
-            onSuccess: (event: UserCodeReceived) -> Unit = {}
-        ) {
-            client.requestUserCode(session.value!!.username) { event ->
-                userCode.value = event.userCode
-                verificationUrl.value = event.verificationUrl
-                expiresIn.value = event.expiresIn
-                interval.value = event.interval
-                canAskForNewTokens.value = true
-                codeExpirationJob.cancel()
-                watchForCodeExpiration()
-                onSuccess(event)
+            is VerifyLogin -> {
+                checkNotNull(stage.value.result) {
+                    "No error message was specified as the result of the `VerifyLogin` stage."
+                }
+                stage.value = LoginFailed(::moveToNextStage, stage.value.result as String)
+            }
+
+            is LoginFailed -> {
+                stage.value = EnterUsername(client, session, ::moveToNextStage)
             }
         }
     }
-
-    /**
-     * A stage in the login flow that indicates a failure in the process.
-     *
-     * Possible reasons for failure include:
-     *
-     * 1. The user is not a member of an authorized organization.
-     * 2. The username obtained in [EnterUsername] stage differs from the username
-     * of the account used to complete [Verify] stage.
-     *
-     * @param cause The reason for the login failure.
-     */
-    public inner class Failed internal constructor(cause: String) : Stage {
-
-        /**
-         * The error message from the login process.
-         */
-        public val errorMessage: StateFlow<String> = MutableStateFlow(cause)
-
-        /**
-         * Starts the login process from the beginning.
-         */
-        public fun restartLogin() {
-            moveToNextStage(EnterUsername())
-        }
-    }
 }
-
-/**
- * Starts the GitHub login process and requests `UserCode`.
- */
-private fun DesktopClient.requestUserCode(
-    username: Username,
-    onSuccess: (event: UserCodeReceived) -> Unit = {}
-) {
-    val command = LogUserIn::class.withSession(
-        SessionId::class.of(username)
-    )
-    observeEventOnce(command.id, UserCodeReceived::class, onSuccess)
-    send(command)
-}
-
-/**
- * Asynchronously performs work with a delay.
- */
-private fun invoke(delay: Duration, action: () -> Unit): Job =
-    CoroutineScope(Dispatchers.Default).launch {
-        delay(delay.inWholeMilliseconds)
-        action()
-    }
-
-/**
- * An error message explaining the cause of `UsernameMismatch` rejection.
- */
-private val UsernameMismatch.cause: String
-    get() = "You entered \"${expectedUser.value}\" as the username but used the code " +
-            "from \"${loggedInUser.value}\" account. You must authenticate with " +
-            "the account matching the username you initially provided."
-
-/**
- * An error message explaining the cause of `NotMemberOfPermittedOrgs` rejection.
- */
-@Suppress("UnusedReceiverParameter" /* Associated with the rejection but doesn't use its data. */)
-private val NotMemberOfPermittedOrgs.cause: String
-    get() = "You are not a member of an organization authorized to use the application."

--- a/client/src/main/kotlin/io/spine/examples/pingh/client/VerifyLogin.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/VerifyLogin.kt
@@ -94,8 +94,7 @@ public class VerifyLogin internal constructor(
     /**
      * The duration after which the [userCode] expires.
      */
-    public val expiresIn: MutableStateFlow<Duration> =
-        MutableStateFlow(event.expiresIn)
+    public val expiresIn: MutableStateFlow<Duration> = MutableStateFlow(event.expiresIn)
 
     /**
      * Whether the user code is expired.

--- a/client/src/main/kotlin/io/spine/examples/pingh/client/VerifyLogin.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/VerifyLogin.kt
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.pingh.client
+
+import com.google.protobuf.Duration
+import io.spine.examples.pingh.github.UserCode
+import io.spine.examples.pingh.github.Username
+import io.spine.examples.pingh.sessions.SessionId
+import io.spine.examples.pingh.sessions.command.LogUserIn
+import io.spine.examples.pingh.sessions.command.VerifyUserLoginToGitHub
+import io.spine.examples.pingh.sessions.event.UserCodeReceived
+import io.spine.examples.pingh.sessions.event.UserIsNotLoggedIntoGitHub
+import io.spine.examples.pingh.sessions.event.UserLoggedIn
+import io.spine.examples.pingh.sessions.of
+import io.spine.examples.pingh.sessions.rejection.Rejections.NotMemberOfPermittedOrgs
+import io.spine.examples.pingh.sessions.rejection.Rejections.UsernameMismatch
+import io.spine.examples.pingh.sessions.withSession
+import io.spine.net.Url
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * A stage of the login flow on which the user enters the received user code
+ * into GitHub to verify their login.
+ *
+ * @property client Enables interaction with the Pingh server.
+ * @property session The information about the current user session.
+ * @property moveToNextStage Switches the current stage to the [LoginFailed].
+ * @param event The event received after the user enters their name.
+ */
+@Suppress("MemberVisibilityCanBePrivate" /* Accessed from `desktop` module. */)
+public class VerifyLogin internal constructor(
+    private val client: DesktopClient,
+    private val session: MutableStateFlow<UserSession?>,
+    private val moveToNextStage: () -> Unit,
+    event: UserCodeReceived
+) : LoginStage<String>() {
+
+    /**
+     * The code a user needs to enter on GitHub to confirm login to the app.
+     */
+    public val userCode: MutableStateFlow<UserCode> = MutableStateFlow(event.userCode)
+
+    /**
+     * The URL of the GitHub resource, where users will be entering the verification code
+     * in scope of the device login flow.
+     */
+    public val verificationUrl: MutableStateFlow<Url> = MutableStateFlow(event.verificationUrl)
+
+    /**
+     * The minimum duration that must pass before user can make a new access token request.
+     */
+    public val interval: MutableStateFlow<Duration> = MutableStateFlow(event.interval)
+
+    /**
+     * Whether a new token can be asked from the external API.
+     *
+     * The contract of the external API assumes some delay that must pass
+     * before a new token can be requested. Therefore, we should wait for this call
+     * to become available.
+     *
+     * @see [interval]
+     */
+    public val canAskForNewTokens: MutableStateFlow<Boolean> = MutableStateFlow(true)
+
+    /**
+     * The duration after which the [userCode] expires.
+     */
+    public val expiresIn: MutableStateFlow<Duration> =
+        MutableStateFlow(event.expiresIn)
+
+    /**
+     * Whether the user code is expired.
+     *
+     * @see [expiresIn]
+     */
+    public val isUserCodeExpired: MutableStateFlow<Boolean> = MutableStateFlow(false)
+
+    /**
+     * Job that marks a [userCode] as expired after the [time][expiresIn] has passed.
+     */
+    private lateinit var codeExpirationJob: Job
+
+    init {
+        watchForCodeExpiration()
+    }
+
+    /**
+     * Starts a job that will mark the [userCode] as expired when [time][expiresIn] passes.
+     */
+    private fun watchForCodeExpiration() {
+        isUserCodeExpired.value = false
+        codeExpirationJob = invoke(expiresIn.value) {
+            isUserCodeExpired.value = true
+        }
+    }
+
+    /**
+     * Checks whether the user has completed the login on GitHub and entered their user code.
+     *
+     * Rejections during verification cause the process to transition to the [LoginFailed] stage.
+     *
+     * @param onSuccess Called when the login is successfully verified.
+     * @param onFail Called when login verification fails.
+     */
+    public fun confirm(
+        onSuccess: (event: UserLoggedIn) -> Unit = {},
+        onFail: (event: UserIsNotLoggedIntoGitHub) -> Unit = {}
+    ) {
+        val command = VerifyUserLoginToGitHub::class.withSession(session.value!!.id)
+        client.observeEither(
+            EventObserver(command.id, UserLoggedIn::class) { event ->
+                codeExpirationJob.cancel()
+                onSuccess(event)
+            },
+            EventObserver(command.id, UserIsNotLoggedIntoGitHub::class) { event ->
+                preventAskingForNewTokens()
+                onFail(event)
+            },
+            EventObserver(command.id, UsernameMismatch::class) { rejection ->
+                codeExpirationJob.cancel()
+                result = rejection.cause
+                moveToNextStage()
+            },
+            EventObserver(command.id, NotMemberOfPermittedOrgs::class) { rejection ->
+                codeExpirationJob.cancel()
+                result = rejection.cause
+                moveToNextStage()
+            }
+        )
+        client.send(command)
+    }
+
+    /**
+     * Prevents requests for new tokens during the [interval].
+     */
+    private fun preventAskingForNewTokens() {
+        canAskForNewTokens.value = false
+        invoke(interval.value) {
+            canAskForNewTokens.value = true
+        }
+    }
+
+    /**
+     * Requests a new `UserCode` on behalf of the current user.
+     *
+     * Resets the current stage to its initial state by canceling all active tasks
+     * and updating fields values with data from the `UserCodeReceived` event.
+     *
+     * @param onSuccess Called when the user code is successfully received.
+     */
+    public fun requestNewUserCode(
+        onSuccess: (event: UserCodeReceived) -> Unit = {}
+    ) {
+        client.requestUserCode(session.value!!.username) { event ->
+            userCode.value = event.userCode
+            verificationUrl.value = event.verificationUrl
+            expiresIn.value = event.expiresIn
+            interval.value = event.interval
+            canAskForNewTokens.value = true
+            codeExpirationJob.cancel()
+            watchForCodeExpiration()
+            onSuccess(event)
+        }
+    }
+}
+
+/**
+ * Starts the GitHub login process and requests `UserCode`.
+ */
+private fun DesktopClient.requestUserCode(
+    username: Username,
+    onSuccess: (event: UserCodeReceived) -> Unit = {}
+) {
+    val command = LogUserIn::class.withSession(
+        SessionId::class.of(username)
+    )
+    observeEventOnce(command.id, UserCodeReceived::class, onSuccess)
+    send(command)
+}
+
+/**
+ * Asynchronously performs work with a delay.
+ */
+private fun invoke(delay: Duration, action: () -> Unit): Job =
+    CoroutineScope(Dispatchers.Default).launch {
+        delay(delay.inWholeMilliseconds)
+        action()
+    }
+
+/**
+ * An error message explaining the cause of `UsernameMismatch` rejection.
+ */
+private val UsernameMismatch.cause: String
+    get() = "You entered \"${expectedUser.value}\" as the username but used the code " +
+            "from \"${loggedInUser.value}\" account. You must authenticate with " +
+            "the account matching the username you initially provided."
+
+/**
+ * An error message explaining the cause of `NotMemberOfPermittedOrgs` rejection.
+ */
+@Suppress("UnusedReceiverParameter" /* Associated with the rejection but doesn't use its data. */)
+private val NotMemberOfPermittedOrgs.cause: String
+    get() = "You are not a member of an organization authorized to use the application."

--- a/client/src/test/kotlin/io/spine/examples/pingh/client/e2e/IntegrationTest.kt
+++ b/client/src/test/kotlin/io/spine/examples/pingh/client/e2e/IntegrationTest.kt
@@ -27,7 +27,7 @@
 package io.spine.examples.pingh.client.e2e
 
 import io.spine.environment.Tests
-import io.spine.examples.pingh.client.LoginFlow.Verify
+import io.spine.examples.pingh.client.VerifyLogin
 import io.spine.examples.pingh.client.PinghApplication
 import io.spine.examples.pingh.client.e2e.given.MemoizingNotificationSender
 import io.spine.examples.pingh.mentions.newMentionsContext
@@ -126,7 +126,7 @@ internal abstract class IntegrationTest {
      *
      * After calling this method, the login verification will be successful,
      * which will allow to use login to the application after calling
-     * the [Verify.confirm] method.
+     * the [VerifyLogin.confirm] method.
      */
     protected fun enterUserCode() {
         auth.enterUserCode()

--- a/client/src/test/kotlin/io/spine/examples/pingh/client/e2e/PersonalInteractionIgTest.kt
+++ b/client/src/test/kotlin/io/spine/examples/pingh/client/e2e/PersonalInteractionIgTest.kt
@@ -29,9 +29,9 @@ package io.spine.examples.pingh.client.e2e
 import com.google.protobuf.Duration
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
-import io.spine.examples.pingh.client.LoginFlow.EnterUsername
-import io.spine.examples.pingh.client.LoginFlow.Verify
+import io.spine.examples.pingh.client.EnterUsername
 import io.spine.examples.pingh.client.MentionsFlow
+import io.spine.examples.pingh.client.VerifyLogin
 import io.spine.examples.pingh.client.e2e.given.expectedMentionsList
 import io.spine.examples.pingh.client.e2e.given.randomUnread
 import io.spine.examples.pingh.client.e2e.given.updateStatusById
@@ -83,7 +83,7 @@ internal class PersonalInteractionIgTest : IntegrationTest() {
         val loginFlow = app().startLoginFlow()
         (loginFlow.currentStage().value as EnterUsername).requestUserCode(username) {
             enterUserCode()
-            (loginFlow.currentStage().value as Verify).confirm(
+            (loginFlow.currentStage().value as VerifyLogin).confirm(
                 onSuccess = {
                     future.complete(null)
                 }

--- a/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/Login.kt
+++ b/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/Login.kt
@@ -79,9 +79,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.google.protobuf.Duration
 import io.spine.examples.pingh.client.LoginFlow
-import io.spine.examples.pingh.client.LoginFlow.EnterUsername
-import io.spine.examples.pingh.client.LoginFlow.Failed
-import io.spine.examples.pingh.client.LoginFlow.Verify
+import io.spine.examples.pingh.client.EnterUsername
+import io.spine.examples.pingh.client.LoginFailed
+import io.spine.examples.pingh.client.VerifyLogin
 import io.spine.examples.pingh.github.UserCode
 import io.spine.examples.pingh.github.Username
 import io.spine.examples.pingh.github.of
@@ -110,12 +110,12 @@ internal fun LoginPage(
             flow = screenStage
         )
 
-        is Verify -> VerificationPage(
+        is VerifyLogin -> VerificationPage(
             flow = screenStage,
             toMentionsPage = toMentionsPage
         )
 
-        is Failed -> FailedPage(
+        is LoginFailed -> FailedPage(
             flow = screenStage
         )
     }
@@ -402,7 +402,7 @@ private fun LoginButton(
  */
 @Composable
 private fun VerificationPage(
-    flow: Verify,
+    flow: VerifyLogin,
     toMentionsPage: () -> Unit
 ) {
     val userCode by flow.userCode.collectAsState()
@@ -520,7 +520,7 @@ private fun CopyToClipboardIcon(
  *   where the user must verify their login.
  */
 @Composable
-private fun CodeExpiredErrorMessage(flow: Verify) {
+private fun CodeExpiredErrorMessage(flow: VerifyLogin) {
     ClickableErrorMessage(
         text = "The code has expired, please start over.",
         clickablePartOfText = "start over",
@@ -599,7 +599,7 @@ private fun VerificationUrlButton(url: Url) {
  */
 @Composable
 private fun SubmitButton(
-    flow: Verify,
+    flow: VerifyLogin,
     toMentionsPage: () -> Unit
 ) {
     val enabled by flow.canAskForNewTokens.collectAsState()
@@ -645,7 +645,7 @@ private fun SubmitButton(
  *   where the user must verify their login.
  */
 @Composable
-private fun NoResponseErrorMessage(flow: Verify) {
+private fun NoResponseErrorMessage(flow: VerifyLogin) {
     val interval by flow.interval.collectAsState()
     ClickableErrorMessage(
         text = """
@@ -722,7 +722,7 @@ private fun ClickableErrorMessage(
  * @param flow The stage in the GitHub login process control flow where the login attempt fails.
  */
 @Composable
-private fun FailedPage(flow: Failed) {
+private fun FailedPage(flow: LoginFailed) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -747,7 +747,7 @@ private fun FailedPage(flow: Failed) {
  * @param flow The stage in the GitHub login process control flow where the login attempt fails.
  */
 @Composable
-private fun RestartButton(flow: Failed) {
+private fun RestartButton(flow: LoginFailed) {
     Button(
         onClick = flow::restartLogin,
         modifier = Modifier


### PR DESCRIPTION
Previously, the stages of the login process were contained within the `LoginFlow` class, allowing them to access process data indiscriminately, even when they shouldn't have had access.

This changeset redesigns the `LoginFlow` class and its stages, moving the stages outside of `LoginFlow`, while still enabling `LoginFlow` to manage stage transitions in the login process.

An abstract class, `LoginStage`, is introduced for all stages to save the results of stage executions. This is essential for `LoginFlow` to create stages that depend on data from the previous stage.