### PR TITLE
 Limit the number of mentions loaded on the first launch

### DIFF
--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubClientProcess.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubClientProcess.kt
@@ -66,7 +66,7 @@ import kotlin.reflect.KClass
 internal val mentionsUpdateInterval: Duration = minutes(1)
 
 /**
- * Limit the number of mentions loaded on the first launch.
+ * The limit the number of mentions loaded on the first launch.
  */
 private const val limitOnFirstLaunch: Int = 20
 

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubClientProcess.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubClientProcess.kt
@@ -202,12 +202,12 @@ internal class GitHubClientProcess :
  *
  * @see [identifyLastWorkday]
  */
-private fun Timestamp.thisOrLastWorkday(): Timestamp {
-    if (!this.isDefault()) {
-        return this
+private fun Timestamp.thisOrLastWorkday(): Timestamp =
+    if (isDefault()) {
+        Timestamp::class.identifyLastWorkday()
+    } else {
+        this
     }
-    return Timestamp::class.identifyLastWorkday()
-}
 
 /**
  * Returns the midnight of the last working day, if counted from the current point in time.

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubSearch.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubSearch.kt
@@ -48,7 +48,7 @@ public interface GitHubSearch {
      * @param token The `PersonalAccessToken` to access user's private repositories.
      * @param updatedAfter The time after which GitHub items containing the searched mentions
      *   should have been updated.
-     * @param onlyOnFirstPage Indicates whether the search should only fetch results
+     * @param onlyOnFirstPage Indicates whether the search retrieves results only
      *   from the first page.
      */
     @Throws(CannotObtainMentionsException::class)

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubSearch.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubSearch.kt
@@ -48,14 +48,13 @@ public interface GitHubSearch {
      * @param token The `PersonalAccessToken` to access user's private repositories.
      * @param updatedAfter The time after which GitHub items containing the searched mentions
      *   should have been updated.
-     * @param onlyOnFirstPage Indicates whether the search retrieves results only
-     *   from the first page.
+     * @param limit The maximum number of recent mentions to return.
      */
     @Throws(CannotObtainMentionsException::class)
     public fun searchMentions(
         username: Username,
         token: PersonalAccessToken,
         updatedAfter: Timestamp = Timestamp.getDefaultInstance(),
-        onlyOnFirstPage: Boolean = true
+        limit: Int? = null
     ): Set<Mention>
 }

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubSearch.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubSearch.kt
@@ -48,11 +48,14 @@ public interface GitHubSearch {
      * @param token The `PersonalAccessToken` to access user's private repositories.
      * @param updatedAfter The time after which GitHub items containing the searched mentions
      *   should have been updated.
+     * @param onlyOnFirstPage Indicates whether the search should only fetch results
+     *   from the first page.
      */
     @Throws(CannotObtainMentionsException::class)
     public fun searchMentions(
         username: Username,
         token: PersonalAccessToken,
-        updatedAfter: Timestamp = Timestamp.getDefaultInstance()
+        updatedAfter: Timestamp = Timestamp.getDefaultInstance(),
+        onlyOnFirstPage: Boolean = true
     ): Set<Mention>
 }

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/RemoteGitHubSearch.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/RemoteGitHubSearch.kt
@@ -92,20 +92,24 @@ public class RemoteGitHubSearch(engine: HttpClientEngine) : GitHubSearch {
         updatedAfter: Timestamp,
         onlyOnFirstPage: Boolean
     ): Set<Mention> =
-        findMentions(username, token, updatedAfter, ItemType.ISSUE, onlyOnFirstPage) +
-                findMentions(username, token, updatedAfter, ItemType.PULL_REQUEST, onlyOnFirstPage)
+        findMentions(username, token, updatedAfter, onlyOnFirstPage, ItemType.ISSUE) +
+                findMentions(username, token, updatedAfter, onlyOnFirstPage, ItemType.PULL_REQUEST)
 
     /**
      * Requests GitHub for mentions of a user in issues or pull requests,
      * then looks for where the user was specifically mentioned on that item.
+     *
+     * If `onlyOnFirstPage` is `false`, pagination is handled during the search.
+     * This means that if not all results are retrieved in the initial request,
+     * additional requests are made to fetch the remaining results.
      */
     @Throws(CannotObtainMentionsException::class)
     private fun findMentions(
         username: Username,
         token: PersonalAccessToken,
         updatedAfter: Timestamp,
-        itemType: ItemType,
-        onlyOnFirstPage: Boolean
+        onlyOnFirstPage: Boolean,
+        itemType: ItemType
     ): Set<Mention> {
         var page = 1
         val firstResult = searchIssuesOrPullRequests(token, updatedAfter, itemType, page)

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/RemoteGitHubSearch.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/RemoteGitHubSearch.kt
@@ -94,9 +94,6 @@ public class RemoteGitHubSearch(engine: HttpClientEngine) : GitHubSearch {
     /**
      * Requests GitHub for mentions of a user in issues or pull requests,
      * then looks for where the user was specifically mentioned on that item.
-     *
-     * Accounts for pagination during the search. If not all results are retrieved in
-     * a single request, additional requests are made to ensure all results are fetched.
      */
     @Throws(CannotObtainMentionsException::class)
     private fun findMentions(

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/RemoteGitHubSearch.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/RemoteGitHubSearch.kt
@@ -55,7 +55,7 @@ import kotlinx.coroutines.runBlocking
  *
  * @see <a href="https://shorturl.at/w35Ao">Changing the number of items per page</a>
  */
-private const val perPage = 20
+private const val perPage = 100
 
 /**
  * Using the GitHub API fetches mentions of a specific user.
@@ -81,8 +81,9 @@ public class RemoteGitHubSearch(engine: HttpClientEngine) : GitHubSearch {
      * @param token The `PersonalAccessToken` to access user's private repositories.
      * @param updatedAfter The time after which GitHub items containing the searched mentions
      *   should have been updated.
-     * @param onlyOnFirstPage If `true`, retrieves mentions only from the first page of results.
-     *   If `false`, fetches all mentions since [updatedAfter].
+     * @param limit The maximum number of recent mentions to return. If set, no more than `limit`
+     *   mentions will be retrieved. If not set, all mentions since
+     *   the [updatedAfter] will be returned.
      * @see [GitHubSearch.searchMentions]
      */
     @Throws(CannotObtainMentionsException::class)
@@ -90,32 +91,38 @@ public class RemoteGitHubSearch(engine: HttpClientEngine) : GitHubSearch {
         username: Username,
         token: PersonalAccessToken,
         updatedAfter: Timestamp,
-        onlyOnFirstPage: Boolean
-    ): Set<Mention> =
-        findMentions(username, token, updatedAfter, onlyOnFirstPage, ItemType.ISSUE) +
-                findMentions(username, token, updatedAfter, onlyOnFirstPage, ItemType.PULL_REQUEST)
+        limit: Int?
+    ): Set<Mention> {
+        require(limit == null || limit > 0) {
+            "The maximum number of recent mentions must be `null` or positive."
+        }
+        return findMentions(username, token, updatedAfter, limit, ItemType.ISSUE) +
+                findMentions(username, token, updatedAfter, limit, ItemType.PULL_REQUEST)
+    }
 
     /**
      * Requests GitHub for mentions of a user in issues or pull requests,
      * then looks for where the user was specifically mentioned on that item.
      *
-     * If `onlyOnFirstPage` is `false`, pagination is handled during the search.
-     * This means that if not all results are retrieved in the initial request,
-     * additional requests are made to fetch the remaining results.
+     * The maximum number of fetched mentions can be restricted by the specified [limit];
+     * if no `limit` is set, all mentions since the [updatedAfter] are retrieved.
+     *
+     * Accounts for pagination during the search. If not all results within `limit` are retrieved
+     * in a single request, additional requests are made to ensure all results are fetched.
      */
     @Throws(CannotObtainMentionsException::class)
     private fun findMentions(
         username: Username,
         token: PersonalAccessToken,
         updatedAfter: Timestamp,
-        onlyOnFirstPage: Boolean,
+        limit: Int?,
         itemType: ItemType
     ): Set<Mention> {
         var page = 1
         val firstResult = searchIssuesOrPullRequests(token, updatedAfter, itemType, page)
         val totalCount = firstResult.totalCount
         val items = firstResult.itemList.toMutableSet()
-        while (!onlyOnFirstPage && perPage * page < totalCount) {
+        while ((limit == null || perPage * page < limit) && perPage * page < totalCount) {
             page++
             items += searchIssuesOrPullRequests(token, updatedAfter, itemType, page).itemList
         }

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/RemoteGitHubSearch.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/RemoteGitHubSearch.kt
@@ -55,7 +55,7 @@ import kotlinx.coroutines.runBlocking
  *
  * @see <a href="https://shorturl.at/w35Ao">Changing the number of items per page</a>
  */
-private const val perPage = 100
+private const val perPage = 20
 
 /**
  * Using the GitHub API fetches mentions of a specific user.
@@ -94,7 +94,7 @@ public class RemoteGitHubSearch(engine: HttpClientEngine) : GitHubSearch {
         limit: Int?
     ): Set<Mention> {
         require(limit == null || limit > 0) {
-            "The maximum number of recent mentions must be `null` or positive."
+            "The maximum number of recent mentions must be `null` or positive value."
         }
         return findMentions(username, token, updatedAfter, limit, ItemType.ISSUE) +
                 findMentions(username, token, updatedAfter, limit, ItemType.PULL_REQUEST)

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/TimestampExts.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/TimestampExts.kt
@@ -40,3 +40,8 @@ internal fun Timestamp.isAfter(time: Timestamp): Boolean = compare(this, time) >
  * Adds the passed duration to this timestamp.
  */
 internal fun Timestamp.add(duration: Duration): Timestamp = Timestamps.add(this, duration)
+
+/**
+ * Returns `true` if this value is the default for `Timestamp`; otherwise, returns `false`.
+ */
+internal fun Timestamp.isDefault(): Boolean = compare(this, this.defaultInstanceForType) == 0

--- a/testutil-mentions/src/main/kotlin/io/spine/examples/pingh/testing/mentions/given/PredefinedGitHubSearchResponses.kt
+++ b/testutil-mentions/src/main/kotlin/io/spine/examples/pingh/testing/mentions/given/PredefinedGitHubSearchResponses.kt
@@ -85,7 +85,8 @@ public class PredefinedGitHubSearchResponses : GitHubSearch {
     public override fun searchMentions(
         username: Username,
         token: PersonalAccessToken,
-        updatedAfter: Timestamp
+        updatedAfter: Timestamp,
+        onlyOnFirstPage: Boolean
     ): Set<Mention> {
         if (responseStatusCode != HttpStatusCode.OK) {
             throw CannotObtainMentionsException(responseStatusCode.value)

--- a/testutil-mentions/src/main/kotlin/io/spine/examples/pingh/testing/mentions/given/PredefinedGitHubSearchResponses.kt
+++ b/testutil-mentions/src/main/kotlin/io/spine/examples/pingh/testing/mentions/given/PredefinedGitHubSearchResponses.kt
@@ -86,7 +86,7 @@ public class PredefinedGitHubSearchResponses : GitHubSearch {
         username: Username,
         token: PersonalAccessToken,
         updatedAfter: Timestamp,
-        onlyOnFirstPage: Boolean
+        limit: Int?
     ): Set<Mention> {
         if (responseStatusCode != HttpStatusCode.OK) {
             throw CannotObtainMentionsException(responseStatusCode.value)


### PR DESCRIPTION
When a user launches the application for the first time, their recent mentions are loaded. Previously, the app loaded all mentions made since the start of the previous workday.

However, this approach could lead to an overwhelming number of mentions, which is impractical. This changeset limits the initial number of mentions loaded to twenty.

As a result, on the first launch, the user will see no more than 20 mentions made since the start of the previous workday. The following requests will fetch all mentions since the last successful mention retrieval, even if the number of mentions exceeds 20.