### PR TITLE
Publish server fat JAR to GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,7 @@ jobs:
           distribution: temurin
 
       - name: Publish package
-        # Since we're in the `master` branch already, this means that tests of a PR passed.
-        # So, no need to run the tests again when publishing.
-        run: ./gradlew publish -x test --stacktrace
+        run: ./gradlew publish --stacktrace
         env:
+          GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Publish
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: temurin
+
+      - name: Publish package
+        # Since we're in the `master` branch already, this means that tests of a PR passed.
+        # So, no need to run the tests again when publishing.
+        run: ./gradlew publish -x test --stacktrace
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -61,6 +61,15 @@ val detektVersion = "1.15.0"
  */
 val dokkaVersion = "1.9.20"
 
+/**
+ * The version of the Shadow Plugin.
+ *
+ * The `6.1.0` version is the last version compatible with Gradle 6.x.
+ *
+ * @see <a href="https://github.com/GradleUp/shadow/releases">Shadow Plugin Releases</a>
+ */
+val shadowVersion = "6.1.0"
+
 configurations.all {
     resolutionStrategy {
         force(
@@ -74,6 +83,7 @@ configurations.all {
 
 dependencies {
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detektVersion")
+    implementation("com.github.jengelman.gradle.plugins:shadow:$shadowVersion")
     implementation("org.jetbrains.dokka:dokka-base:$dokkaVersion")
     implementation("org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion")
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publishing/GitHubPackages.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publishing/GitHubPackages.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.publishing
+
+import java.net.URI
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+
+/**
+ * Adds maven repository of Pingh project hosted at GitHub Packages.
+ *
+ * Authentication is handled using the GitHub actor and GitHub token from
+ * the environment variables.
+ *
+ * @see <a href="">Publishing packages to GitHub Packages</a>
+ */
+public fun RepositoryHandler.gitHubPackages() {
+    maven {
+        name = "GitHubPackages"
+        url = URI("https://maven.pkg.github.com/spine-examples/Pingh")
+        credentials {
+            username = actor()
+            password = token()
+        }
+    }
+}
+
+/**
+ * Returns the GitHub actor from the environment variable if it exists;
+ * otherwise, returns the default actor.
+ */
+private fun actor(): String = System.getenv("GITHUB_ACTOR") ?: "developers@spine.io"
+
+/**
+ * Returns the GitHub token from the environment variables.
+ *
+ * @throws IllegalStateException if GitHub token doesn't exist.
+ */
+private fun token(): String = System.getenv("GITHUB_TOKEN") ?: throw IllegalStateException(
+    "GitHub token for publication is not found in env variables."
+)

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publishing/GitHubPackages.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publishing/GitHubPackages.kt
@@ -35,7 +35,7 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler
  * Authentication is handled using the GitHub actor and GitHub token from
  * the environment variables.
  *
- * @see <a href="">Publishing packages to GitHub Packages</a>
+ * @see <a href="https://shorturl.at/AuxHg">Publishing packages to GitHub Packages</a>
  */
 public fun RepositoryHandler.gitHubPackages() {
     maven {

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publishing/GitHubPackages.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publishing/GitHubPackages.kt
@@ -55,10 +55,7 @@ public fun RepositoryHandler.gitHubPackages() {
 private fun actor(): String = System.getenv("GITHUB_ACTOR") ?: "developers@spine.io"
 
 /**
- * Returns the GitHub token from the environment variables.
- *
- * @throws IllegalStateException if GitHub token doesn't exist.
+ * Returns the GitHub token from the environment variables if it exists;
+ * otherwise, returns empty string.
  */
-private fun token(): String = System.getenv("GITHUB_TOKEN") ?: throw IllegalStateException(
-    "GitHub token for publication is not found in env variables."
-)
+private fun token(): String = System.getenv("GITHUB_TOKEN") ?: ""

--- a/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
+++ b/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
@@ -28,6 +28,6 @@ package io.spine.internal.dependency
 
 // https://github.com/spine-examples/Pingh
 public object Pingh {
-    private const val version = "1.0.0-SNAPSHOT"
+    private const val version = "1.0.0-SNAPSHOT.1"
     public const val client: String = "io.spine.examples.pingh:client:$version"
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -95,7 +95,7 @@ publishing {
         create("fatJar", MavenPublication::class) {
             groupId = project.group.toString()
             artifactId = "pingh-server"
-            version = project.version.toString() + ".1"
+            version = project.version.toString()
 
             artifact(tasks.shadowJar) {
                 // Avoid `-all` suffix in the published artifact.

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -30,6 +30,7 @@ import io.spine.internal.dependency.Guava
 import io.spine.internal.dependency.Ktor
 import io.spine.internal.dependency.Spine
 import io.spine.internal.dependency.Testcontainers
+import io.spine.internal.gradle.publishing.gitHubPackages
 
 plugins {
     // Add the Gradle plugin for bootstrapping projects built with Spine.
@@ -37,6 +38,7 @@ plugins {
     id("io.spine.tools.gradle.bootstrap").version("1.9.0")
     id("com.github.johnrengelman.shadow")
     application
+    `maven-publish`
 }
 
 forceGrpcDependencies(configurations)
@@ -64,6 +66,7 @@ dependencies {
 }
 
 val appClassName = "io.spine.examples.pingh.server.PinghServerKt"
+project.setProperty("mainClassName", appClassName)
 
 tasks.withType<ShadowJar> {
     mergeServiceFiles("desc.ref")
@@ -81,4 +84,23 @@ tasks.withType<ShadowJar> {
 
 application {
     mainClass.set(appClassName)
+}
+
+publishing {
+    repositories {
+        gitHubPackages()
+    }
+
+    publications {
+        create("fatJar", MavenPublication::class) {
+            groupId = project.group.toString()
+            artifactId = "pingh-server"
+            version = project.version.toString()
+
+            artifact(tasks.shadowJar) {
+                // Avoid `-all` suffix in the published artifact.
+                classifier = ""
+            }
+        }
+    }
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -95,7 +95,7 @@ publishing {
         create("fatJar", MavenPublication::class) {
             groupId = project.group.toString()
             artifactId = "pingh-server"
-            version = project.version.toString()
+            version = project.version.toString() + ".1"
 
             artifact(tasks.shadowJar) {
                 // Avoid `-all` suffix in the published artifact.

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import io.spine.internal.dependency.Grpc
 import io.spine.internal.dependency.Guava
 import io.spine.internal.dependency.Ktor
@@ -34,7 +35,7 @@ plugins {
     // Add the Gradle plugin for bootstrapping projects built with Spine.
     // See: https://github.com/SpineEventEngine/bootstrap
     id("io.spine.tools.gradle.bootstrap").version("1.9.0")
-
+    id("com.github.johnrengelman.shadow")
     application
 }
 
@@ -62,6 +63,22 @@ dependencies {
     implementation(Testcontainers.gcloud)
 }
 
+val appClassName = "io.spine.examples.pingh.server.PinghServerKt"
+
+tasks.withType<ShadowJar> {
+    mergeServiceFiles("desc.ref")
+    mergeServiceFiles("META-INF/services/io.spine.option.OptionsProvider")
+    manifest {
+        attributes["Main-Class"] = appClassName
+    }
+    exclude(
+        // Protobuf files.
+        "google/**",
+        "spine/**",
+        "spine_examples/**"
+    )
+}
+
 application {
-    mainClass.set("io.spine.examples.pingh.server.PinghServerKt")
+    mainClass.set(appClassName)
 }

--- a/sessions/src/main/java/io/spine/examples/pingh/sessions/package-info.java
+++ b/sessions/src/main/java/io/spine/examples/pingh/sessions/package-info.java
@@ -28,7 +28,7 @@
  * Provides server-side code of the Sessions bounded context.
  */
 @BoundedContext(NAME)
-package io.spine.exampless.pingh.sessions;
+package io.spine.examples.pingh.sessions;
 
 import io.spine.core.BoundedContext;
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of the `Pingh` to publish.
  */
-val pinghVersion: String by extra("1.0.0-SNAPSHOT")
+val pinghVersion: String by extra("1.0.0-SNAPSHOT.1")


### PR DESCRIPTION
To enable the deployment of the Pingh server on Google Cloud, this changeset introduces the creation of a fat JAR file. This file is published to the GitHub Packages Registry each time a merge to the `master` branch occurs.

# Configuring for the remote deployment

1. Add the following environment variables:

- `GITHUB_ACTOR`: The GitHub user or team responsible for performing the publishing action.
- `GITHUB_TOKEN`: A user access token with the `write:packages` permission.

These values are required to successfully publish the JAR file to the GitHub Packages Registry.

2. In the project directory, run the following command:

```shell
./gradlew publish
```

This will create a fat JAR of the Pingh server and publish it to GitHub Packages in the `spine-examples/Pingh` repository. The `GITHUB_ACTOR` and `GITHUB_TOKEN` environment variables set earlier will be used for authentication.

3. Upload the published JAR to the server machine. To download the Pingh server from the GitHub Packages Registry, make a `GET` request using following URL:

`https://maven.pkg.github.com/spine-examples/Pingh/io/spine/examples/pingh/pingh-server/$VERSION/pingh-server-$VERSION.jar`

Replace `VERSION` with the version of the server you want to install. The latest version can be retrieved from `maven-metadata.xml` file. To obtain it, make a `GET` request using following URL:

`https://maven.pkg.github.com/spine-examples/Pingh/io/spine/examples/pingh/pingh-server/maven-metadata.xml`

Note that you need a personal access token with the `read:packages` permission to access these resources.

4. Start the server. Ensure that JRE 11 is [installed](https://www.oracle.com/cis/java/technologies/javase/jdk11-archive-downloads.html) on the machine. To start the server, execute the following command:

``` shell
java -jar $ARTIFACT
```

Replace `ARTIFACT` with the name of the fat JAR file downloaded in the previous step.

The server always starts on port `50051`, so ensure that this port is open. The server's address is the machine's IP address, such as `0.1.2.3`.

On the Pingh server VM hosted on Google Cloud, an `updateAndRunServer.sh` script is available in the root directory. This script downloads the latest version of the Pingh server and starts it.

5. Configure the client connection to the server. Open the `server.properties` file located in the resources directory of the client project and enter the server's address and port:

```properties
server.address=0.1.2.3
server.port=50051
```

6. Build and run the client distribution by executing the following command in the project directory:

```shell
./gradlew build runDistributable
```

It will create and immediately start the runnable distribution.

To just create a distribution of the client application, use the following command:

```shell
./gradlew build createDistributable
```