### PR TITLE
Enable Google Cloud Secret Manager

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/GCloud.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/GCloud.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.dependency
+
+public object GCloud {
+    private const val group = "com.google.cloud"
+
+    // https://github.com/googleapis/google-cloud-java/tree/main/java-secretmanager
+    public object SecretManager {
+        // The selected version is compatible with Protobuf 3.13.0, which is used by Spine 1.9.0.
+        private const val version = "1.4.2"
+        public const val lib: String = "$group:google-cloud-secretmanager:$version"
+    }
+}

--- a/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
+++ b/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
@@ -28,6 +28,6 @@ package io.spine.internal.dependency
 
 // https://github.com/spine-examples/Pingh
 public object Pingh {
-    private const val version = "1.0.0-SNAPSHOT.1"
+    private const val version = "1.0.0-SNAPSHOT.2"
     public const val client: String = "io.spine.examples.pingh:client:$version"
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -25,6 +25,7 @@
  */
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import io.spine.internal.dependency.GCloud
 import io.spine.internal.dependency.Grpc
 import io.spine.internal.dependency.Guava
 import io.spine.internal.dependency.Ktor
@@ -59,6 +60,7 @@ dependencies {
     implementation(Guava.lib)
     implementation(Grpc.netty)
     implementation(Grpc.inprocess)
+    implementation(GCloud.SecretManager.lib)
     implementation(Spine.GCloud.datastore)
     implementation(Spine.GCloud.testutil)
     implementation(Testcontainers.lib)
@@ -69,6 +71,7 @@ val appClassName = "io.spine.examples.pingh.server.PinghServerKt"
 project.setProperty("mainClassName", appClassName)
 
 tasks.withType<ShadowJar> {
+    mergeServiceFiles()
     mergeServiceFiles("desc.ref")
     mergeServiceFiles("META-INF/services/io.spine.option.OptionsProvider")
     manifest {

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -99,6 +99,7 @@ publishing {
             groupId = project.group.toString()
             artifactId = "pingh-server"
             version = project.version.toString()
+            description = "Pingh app server."
 
             artifact(tasks.shadowJar) {
                 // Avoid `-all` suffix in the published artifact.

--- a/server/src/main/kotlin/io/spine/examples/pingh/server/PinghServer.kt
+++ b/server/src/main/kotlin/io/spine/examples/pingh/server/PinghServer.kt
@@ -46,16 +46,12 @@ import io.spine.examples.pingh.sessions.newSessionsContext
 /**
  * The client ID for the Pingh GitHub App.
  */
-// TODO:2024-07-29:mykyta.pimonov: Load a key from the Google Secret Manager
-//  after deployment to the Google Cloud.
-private val clientId = ClientId::class.of("client_id")
+private val clientId = ClientId::class.of(Secret.named("github_client_id"))
 
 /**
  * The client secret of the Pingh GitHub App.
  */
-// TODO:2024-08-28:mykyta.pimonov: Load a key from the Google Secret Manager
-//  after deployment to the Google Cloud.
-private val clientSecret = ClientSecret::class.of("client_id")
+private val clientSecret = ClientSecret::class.of(Secret.named("github_client_secret"))
 
 /**
  * The entry point of the server application.

--- a/server/src/main/kotlin/io/spine/examples/pingh/server/Secret.kt
+++ b/server/src/main/kotlin/io/spine/examples/pingh/server/Secret.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.pingh.server
+
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient
+import com.google.cloud.secretmanager.v1.SecretVersionName
+
+/**
+ * Allows to access application secrets stored
+ * in [Google Secret Manager](https://cloud.google.com/secret-manager).
+ */
+internal object Secret {
+    /**
+     * The Google Cloud Platform project ID.
+     */
+    private val projectId: String
+        get() = System.getProperty("GCP_PROJECT_ID")
+
+    /**
+     * Retrieves the secret with the specified [name][secretId].
+     *
+     * The latest version of the secret available in the current [project][projectId] is retrieved.
+     *
+     * To retrieve the secret, the [project ID][projectId] must be provided as
+     * a system parameter with the key `GCP_PROJECT_ID`.
+     */
+    internal fun named(secretId: String): String =
+        SecretManagerServiceClient.create().use { client ->
+            val version = SecretVersionName.of(projectId, secretId, "latest")
+            client.accessSecretVersion(version)
+                .payload
+                .data
+                .toStringUtf8()
+        }
+}

--- a/server/src/main/kotlin/io/spine/examples/pingh/server/Secret.kt
+++ b/server/src/main/kotlin/io/spine/examples/pingh/server/Secret.kt
@@ -31,7 +31,7 @@ import com.google.cloud.secretmanager.v1.SecretVersionName
 
 /**
  * Allows to access application secrets stored
- * in [Google Secret Manager](https://cloud.google.com/secret-manager).
+ * in [Google Cloud Secret Manager](https://cloud.google.com/secret-manager).
  */
 internal object Secret {
     /**

--- a/server/src/main/kotlin/io/spine/examples/pingh/server/Secret.kt
+++ b/server/src/main/kotlin/io/spine/examples/pingh/server/Secret.kt
@@ -35,12 +35,6 @@ import com.google.cloud.secretmanager.v1.SecretVersionName
  */
 internal object Secret {
     /**
-     * The Google Cloud Platform project ID.
-     */
-    private val projectId: String
-        get() = System.getProperty("GCP_PROJECT_ID")
-
-    /**
      * Retrieves the secret with the specified [name][secretId].
      *
      * The latest version of the secret available in the current [project][projectId] is retrieved.
@@ -50,10 +44,20 @@ internal object Secret {
      */
     internal fun named(secretId: String): String =
         SecretManagerServiceClient.create().use { client ->
-            val version = SecretVersionName.of(projectId, secretId, "latest")
+            val version = SecretVersionName.of(projectId(), secretId, "latest")
             client.accessSecretVersion(version)
                 .payload
                 .data
                 .toStringUtf8()
         }
+
+    /**
+     * Returns the Google Cloud Platform project ID from system properties.
+     *
+     * @throws IllegalStateException if `GCP_PROJECT_ID` property is empty.
+     */
+    private fun projectId(): String =
+        System.getProperty("GCP_PROJECT_ID") ?: throw IllegalStateException(
+            "The project ID is not specified as a system property using the `GCP_PROJECT_ID` key."
+        )
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of the `Pingh` to publish.
  */
-val pinghVersion: String by extra("1.0.0-SNAPSHOT.1")
+val pinghVersion: String by extra("1.0.0-SNAPSHOT.2")


### PR DESCRIPTION
Pingh is a GitHub application that requires the client ID and secret provided by GitHub to make authentication requests on its behalf.

This changeset retrieves GitHub secrets from Google Cloud [Secret Manager](https://cloud.google.com/security/products/secret-manager) for configuring the Pingh server. This ensures that the GitHub client ID and secret remain protected.

### Server configuration

1. Add secrets to Secret Manager:
- `github_client_id`: The client ID of a GitHub App.
- `github_client_secret`: The client secret of a GitHub App.

2. Grant the Compute Engine instance's service account the [Secret Manager Secret Accessor](https://cloud.google.com/secret-manager/docs/access-secret-version#required_roles) role and add the [cloud-platform](https://cloud.google.com/secret-manager/docs/accessing-the-api#oauth-scopes) OAuth scope. This is required to allow the VM running the server to access data from Secret Manager.

3. Add the JVM parameter `GCP_PROJECT_ID` with the Google Cloud project ID value, when starting the server JAR file. To start the server, execute the following command:

```shell
java -DGCP_PROJECT_ID=$PROJECT_ID -jar $ARTIFACT
```

Replace `PROJECT_ID` with the Google Cloud project ID and `ARTIFACT` with the name of the server JAR file.

Note that the Pingh Google Cloud server is already configured, and the `updateAndRunServer.sh` script now also retrieves and specifies the project ID.