### PR TITLE
Use Google Cloud Datastore for data storage

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/GCloud.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/GCloud.kt
@@ -35,4 +35,10 @@ public object GCloud {
         private const val version = "1.4.2"
         public const val lib: String = "$group:google-cloud-secretmanager:$version"
     }
+
+    // https://github.com/googleapis/java-datastore
+    public object Datastore {
+        private const val version = "2.14.2"
+        public const val lib: String = "$group:google-cloud-datastore:$version"
+    }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -24,26 +24,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import io.spine.internal.dependency.Grpc
-import io.spine.internal.dependency.Guava
-import io.spine.internal.dependency.Protobuf
-import org.gradle.api.artifacts.ConfigurationContainer
+package io.spine.internal.dependency
 
-/**
- * Forces dependencies for gRPC operation in the project.
- *
- * Also forces necessary transitive dependencies.
- */
-public fun forceGrpcDependencies(configurations: ConfigurationContainer) {
-    configurations.all {
-        resolutionStrategy {
-            force(
-                Guava.lib,
-                Grpc.netty,
-                Grpc.inprocess,
-                Protobuf.java,
-                Protobuf.javaUtil
-            )
-        }
-    }
+// https://github.com/protocolbuffers/protobuf
+public object Protobuf {
+    private const val group = "com.google.protobuf"
+    public const val version: String = "3.19.4"
+
+    public const val java: String = "$group:protobuf-java:${version}"
+    public const val javaUtil: String = "$group:protobuf-java-util:${version}"
 }

--- a/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
+++ b/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
@@ -28,6 +28,6 @@ package io.spine.internal.dependency
 
 // https://github.com/spine-examples/Pingh
 public object Pingh {
-    private const val version = "1.0.0-SNAPSHOT.2"
+    private const val version = "1.0.0-SNAPSHOT.3"
     public const val client: String = "io.spine.examples.pingh:client:$version"
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -29,6 +29,7 @@ import io.spine.internal.dependency.GCloud
 import io.spine.internal.dependency.Grpc
 import io.spine.internal.dependency.Guava
 import io.spine.internal.dependency.Ktor
+import io.spine.internal.dependency.Protobuf
 import io.spine.internal.dependency.Spine
 import io.spine.internal.dependency.Testcontainers
 import io.spine.internal.gradle.publishing.gitHubPackages
@@ -61,10 +62,25 @@ dependencies {
     implementation(Grpc.netty)
     implementation(Grpc.inprocess)
     implementation(GCloud.SecretManager.lib)
+    implementation(Protobuf.java)
+    implementation(Protobuf.javaUtil)
     implementation(Spine.GCloud.datastore)
     implementation(Spine.GCloud.testutil)
     implementation(Testcontainers.lib)
     implementation(Testcontainers.gcloud)
+}
+
+/**
+ * For Google Cloud Datastore to function correctly, Protobuf version 3.18 or higher is required.
+ * Since Protobuf is included as a transitive dependency in many Google and Spine libraries,
+ * it is necessary to explicitly specify the required version for the project.
+ */
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "com.google.protobuf" && requested.name == "protobuf-java") {
+            useVersion(Protobuf.version)
+        }
+    }
 }
 
 val appClassName = "io.spine.examples.pingh.server.PinghServerKt"

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     implementation(Grpc.netty)
     implementation(Grpc.inprocess)
     implementation(GCloud.SecretManager.lib)
+    implementation(GCloud.Datastore.lib)
     implementation(Protobuf.java)
     implementation(Protobuf.javaUtil)
     implementation(Spine.GCloud.datastore)

--- a/server/src/main/kotlin/io/spine/examples/pingh/server/PinghServer.kt
+++ b/server/src/main/kotlin/io/spine/examples/pingh/server/PinghServer.kt
@@ -32,13 +32,13 @@ import io.spine.examples.pingh.mentions.newMentionsContext
 import io.spine.server.Server
 import io.spine.server.ServerEnvironment
 import io.spine.server.delivery.Delivery
-import io.spine.server.storage.memory.InMemoryStorageFactory
 import io.spine.server.transport.memory.InMemoryTransportFactory
 import io.spine.client.ConnectionConstants.DEFAULT_CLIENT_SERVICE_PORT
 import io.spine.examples.pingh.github.ClientId
 import io.spine.examples.pingh.github.ClientSecret
 import io.spine.examples.pingh.github.of
 import io.spine.examples.pingh.mentions.RemoteGitHubSearch
+import io.spine.examples.pingh.server.datastore.DatastoreStorageFactory
 import io.spine.examples.pingh.sessions.RemoteGitHubAuthentication
 import io.spine.examples.pingh.sessions.RemoteGitHubUsers
 import io.spine.examples.pingh.sessions.newSessionsContext
@@ -87,14 +87,13 @@ private fun createServer(): Server {
 /**
  * Configures the server environment.
  *
- * Server side of this application is currently running in in-memory storage mode.
- * Therefore, any changes made by users of this application will not be persisted
- * in-between the application launches.
+ * Application data is stored using Google Cloud Datastore. Therefore, any changes made
+ * by users of this application will be persisted in-between the application launches.
  */
 private fun configureEnvironment() {
     ServerEnvironment
         .`when`(DefaultMode::class.java)
-        .use(InMemoryStorageFactory.newInstance())
+        .use(DatastoreStorageFactory.remote())
         .use(Delivery.localAsync())
         .use(InMemoryTransportFactory.newInstance())
 }

--- a/server/src/main/kotlin/io/spine/examples/pingh/server/datastore/DatastoreStorageFactory.kt
+++ b/server/src/main/kotlin/io/spine/examples/pingh/server/datastore/DatastoreStorageFactory.kt
@@ -26,6 +26,9 @@
 
 package io.spine.examples.pingh.server.datastore
 
+import com.google.cloud.datastore.DatastoreOptions
+import io.spine.server.storage.datastore.DatastoreStorageFactory
+import io.spine.server.storage.datastore.DsColumnMapping
 import io.spine.server.storage.datastore.ProjectId
 import io.spine.testing.server.storage.datastore.TestDatastoreStorageFactory
 
@@ -54,4 +57,33 @@ public object DatastoreStorageFactory {
             .service
         return TestDatastoreStorageFactory.basedOn(datastore)
     }
+
+    /**
+     * Creates a factory for generating `Storage`s based on remote Google Cloud Datastore.
+     *
+     * Uses a Datastore named `(default)`.
+     *
+     * To connect to the Datastore, the [project ID][projectId] must be specified as
+     * a system parameter with the key `GCP_PROJECT_ID`.
+     */
+    public fun remote(): DatastoreStorageFactory {
+        val datastore = DatastoreOptions.newBuilder()
+            .setProjectId(projectId())
+            .build()
+            .service
+        return DatastoreStorageFactory.newBuilder()
+            .setDatastore(datastore)
+            .setColumnMapping(DsColumnMapping())
+            .build()
+    }
+
+    /**
+     * Returns the Google Cloud Platform project ID from system properties.
+     *
+     * @throws IllegalStateException if `GCP_PROJECT_ID` property is empty.
+     */
+    private fun projectId(): String =
+        System.getProperty("GCP_PROJECT_ID") ?: throw IllegalStateException(
+            "The project ID is not specified as a system property using the `GCP_PROJECT_ID` key."
+        )
 }

--- a/server/src/main/resources/datastore/config/index.yaml
+++ b/server/src/main/resources/datastore/config/index.yaml
@@ -1,0 +1,45 @@
+#
+# Copyright 2024, TeamDev. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Redistribution and use in source and/or binary forms, with or without
+# modification, must retain the above copyright notice and the following
+# disclaimer.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+indexes:
+  - kind: spine.core.Event
+    ancestor: no
+    properties:
+      - name: type
+      - name: created
+
+  - kind: spine.server.delivery.InboxMessage
+    properties:
+      - name: inbox_shard
+      - name: of_total_inbox_shards
+      - name: received_at
+      - name: version
+
+  - kind: spine.server.delivery.InboxMessage
+    properties:
+      - name: inbox_shard
+      - name: of_total_inbox_shards
+      - name: status

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of the `Pingh` to publish.
  */
-val pinghVersion: String by extra("1.0.0-SNAPSHOT.2")
+val pinghVersion: String by extra("1.0.0-SNAPSHOT.3")


### PR DESCRIPTION
Previously, the server side of this application operated in in-memory storage mode, meaning that any changes made by users were not retained between application restarts.

This changeset configures the server to use Google Cloud [Datastore](https://cloud.google.com/products/datastore) for data storage, ensuring that user changes are persisted across application launches.

### Server configuration

1. Grant the Compute Engine instance's service account the `Cloud Datastore User` role and add the `datastore` OAuth scope. This is required to allow the VM running the server to read and write data in Datastore.

2. The Datastore instance requires preliminary configuration, specifically setting up indexes for Spine's internal record types.

The configuration file can be found in the server's resources directory at `datastore/config/index.yaml`.

For more details, refer to the [Google Cloud Platform](https://cloud.google.com/datastore/docs/tools/indexconfig) documentation.

Note that the Pingh Google Cloud server is already configured.

Also, the connection is made to the default database (named `(default)`) and cannot be modified.