### PR TITLE
Add authentication to the heartbeat server

### DIFF
--- a/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
+++ b/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
@@ -28,6 +28,6 @@ package io.spine.internal.dependency
 
 // https://github.com/spine-examples/Pingh
 public object Pingh {
-    private const val version = "1.0.0-SNAPSHOT.4"
+    private const val version = "1.0.0-SNAPSHOT.5"
     public const val client: String = "io.spine.examples.pingh:client:$version"
 }

--- a/server/src/main/kotlin/io/spine/examples/pingh/server/HeartbeatServer.kt
+++ b/server/src/main/kotlin/io/spine/examples/pingh/server/HeartbeatServer.kt
@@ -63,8 +63,8 @@ internal fun startHeartbeatServer(clock: Clock) {
  * If the "Authorization" header is missing or does not match the Compute Engine
  * authentication token stored in Secret Manager, the request will be rejected
  * with a `401 Unauthorized` status code. Otherwise, upon receiving a request with valid
- * authorization token, the server will emit an event with the current time and
- * return a `200 OK` status in response.
+ * authentication token, the server will emit an event with the current time and
+ * return a `200 OK` status code in response.
  */
 private fun Application.configure(clock: Clock) {
     val token = Secret.named("auth_token")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of the `Pingh` to publish.
  */
-val pinghVersion: String by extra("1.0.0-SNAPSHOT.4")
+val pinghVersion: String by extra("1.0.0-SNAPSHOT.5")


### PR DESCRIPTION
The heartbeat server accepts HTTP requests to periodically send the current time to bounded contexts. Previously, any request sent to the `/time` endpoint was accepted and would trigger a `TimePassed` event. This allowed anyone to send requests to this endpoint, potentially leading to server overload.

This set of changes introduces authentication for the `/time` endpoint. Now, a request will only be accepted if the "Authorization" header matches the authentication token retrieved from Google Secret Manager.

### Server configuration

1. Add secrets to Secret Manager:

- `auth_token`: The authentication token required for accessing the heartbeat server running on the VM.

2. Configure the Google Scheduler task to send a request that includes the "Authorization" header with the `auth_token` value specified earlier.