### PR TITLE
Fix `LocalUriHandler not present` exception

### DIFF
--- a/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
+++ b/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://github.com/spine-examples/Pingh
 public object Pingh {
-    private const val version = "1.0.0-SNAPSHOT.11"
+    private const val version = "1.0.0-SNAPSHOT.12"
     private const val group = "io.spine.examples.pingh"
 
     public const val client: String = "$group:client:$version"

--- a/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/Window.kt
+++ b/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/Window.kt
@@ -50,29 +50,23 @@ import io.spine.examples.pingh.client.PinghApplication
  *
  * @param state The state of the application window.
  * @param app Manages the logic for the Pingh app.
- * @param uriHandler The `CompositionLocal` that provides functionality for handling URL,
- *   such as opening a URI.
+ * @param uriHandler Provides functionality for handling URL, such as opening a URI.
  * @see [PlatformWindow]
  */
 @Composable
 internal fun Window(
     state: WindowState,
     app: PinghApplication,
-    uriHandler: UriHandler = LocalUriHandler.current
+    uriHandler: UriHandler? = null
 ) {
     PlatformWindow(
         title = state.title,
         isShown = state.isShown,
         onClose = state::hide
     ) {
-        CompositionLocalProvider(LocalUriHandler provides uriHandler) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .clip(MaterialTheme.shapes.small)
-            ) {
-                CurrentPage(app)
-            }
+        val localUriHandler = uriHandler ?: LocalUriHandler.current
+        CompositionLocalProvider(LocalUriHandler provides localUriHandler) {
+            WindowContent(app)
         }
     }
 }
@@ -109,6 +103,20 @@ private fun PlatformWindow(
         alwaysOnTop = true,
         content = content
     )
+}
+
+/**
+ * Displays a content in the Pingh window.
+ */
+@Composable
+private fun WindowContent(app: PinghApplication) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .clip(MaterialTheme.shapes.small)
+    ) {
+        CurrentPage(app)
+    }
 }
 
 /**

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of the `Pingh` to publish.
  */
-val pinghVersion: String by extra("1.0.0-SNAPSHOT.11")
+val pinghVersion: String by extra("1.0.0-SNAPSHOT.12")


### PR DESCRIPTION
When building a distribution of the client application, the user encountered an `IllegalStateException`. This exception occurred when attempting to retrieve the `LocalUriHandler` from `CompositionLocals` before the window was created, as this value was not defined outside of the window.

This changeset relocates the retrieval of the `LocalUriHandler` from `CompositionLocals` to within the created window, where the value is already defined. This adjustment resolves the exception that occurs during application startup.