### PR TITLE
Enable compatibility with JDK higher than 17 for client app and update permitted organizations config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Client stack:
 
 - Kotlin 1.9.20.
 - Compose Multiplatform 1.6.11.
-- JDK 17 or higher.
+- JDK 17.
 
 Builds with Gradle 8.10.x. Runs locally.
 
@@ -64,7 +64,7 @@ When running the application locally, consider the following:
 
 ### Prerequisites
 
-- JDK 11 and JDK 17 or higher.
+- JDK 11 and JDK 17.
 - Docker Desktop.
 
 ### Build
@@ -82,7 +82,20 @@ github-app.client.secret=client_secret
 
 Replace `client_id` and `client_secret` with the values obtained from GitHub.
 
-2. Start the Pingh server locally. The server always runs on port `50051`. 
+2. Specify the names of organizations permitted to use the application. To do this, 
+  open `config/authentication.properties` file in the `sessions` resources directory 
+  and enter the organization names as a comma-separated string without spaces. 
+  For instance, for organizations `spine-examples` and `SpineEventEngine`, enter:
+
+```properties
+permitted-organizations=spine-examples,SpineEventEngine
+```
+
+Additionally, ensure that each specified organization has 
+the [GitHub App](https://github.com/apps/pingh-tracker-of-github-mentions) installed; 
+otherwise, authentication will fail.
+ 
+3. Start the Pingh server locally. The server always runs on port `50051`. 
   To launch it, run the following command in the root project directory:
 
 ```shell
@@ -92,8 +105,8 @@ Replace `client_id` and `client_secret` with the values obtained from GitHub.
 This will start the server on `localhost:50051` and publish the required JAR files 
 for the client application to the Maven Local repository.
 
-3. Configure the client's connection to the server. To do this, 
-  open the `config/server.properties` file in the client project resources directory 
+4. Configure the client's connection to the server. To do this, 
+  open the `config/server.properties` file in the resources directory of the `desktop` module
   and enter the server's address and port as follows:
 
 ```properties
@@ -101,7 +114,7 @@ server.address=localhost
 server.port=50051
 ```
 
-4. Build and run the client application. Navigate to the client project directory 
+5. Build and run the client application. Navigate to the `desktop` module directory 
   and execute the following command:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ When running the application locally, consider the following:
 
 ### Prerequisites
 
-- JDK 11 and JDK 17.
+- JDK 11 and 17.
 - Docker Desktop.
 
 ### Build
@@ -191,6 +191,23 @@ The following secrets are configured for the Pingh app:
 - `github_client_id`: The client ID of a GitHub App.
 - `github_client_secret`: The client secret of a GitHub App.
 - `auth_token`: The authentication token required for accessing the HTTP server running on the VM.
+
+## Testing
+
+This project includes several types of testing.
+
+1. Unit tests focus on the behavior of entities within bounded contexts, using the Black Box 
+  provided by the Spine server testing API.
+
+2. End-to-end tests validate client-server interactions by starting the server and
+  running various user scenarios, with a Datastore emulator used for data storage.
+
+3. UI tests are created with the Testing Compose Multiplatform UI API 
+  to verify the functionality of the client application, 
+  with a test server also launched for these tests.
+
+A Docker environment is required for end-to-end and UI testing, 
+as the Datastore emulator is automatically started in a Docker container.
 
 ## Feedback
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Client stack:
 
 - Kotlin 1.9.20.
 - Compose Multiplatform 1.6.11.
-- JDK 17.
+- JDK 17 or higher.
 
 Builds with Gradle 8.10.x. Runs locally.
 
@@ -64,7 +64,7 @@ When running the application locally, consider the following:
 
 ### Prerequisites
 
-- JDK 11 and 17.
+- JDK 11 and JDK 17 or higher.
 - Docker Desktop.
 
 ### Build

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ When running the application locally, consider the following:
 To run the application locally, download the project from GitHub and follow these steps:
 
 1. Specify the GitHub App ID and secret in the configuration file. To do this, 
-  open the `local/config/server.properties` file in the `server` resources directory
-  and enter the GitHub App ID and secret as follows:
+  enter the GitHub App ID and secret 
+  in the `server/src/main/resources/local/config/server.properties` as follows:
 
 ```properties
 github-app.client.id=client_id
@@ -82,13 +82,13 @@ github-app.client.secret=client_secret
 
 Replace `client_id` and `client_secret` with the values obtained from GitHub.
 
-2. Specify the names of organizations permitted to use the application. To do this, 
-  open `config/authentication.properties` file in the `sessions` resources directory 
-  and enter the organization names as a comma-separated string without spaces. 
+2. The application can be used only by members of certain organizations. 
+  Specify the names of these organizations separated by commas 
+  in the `sessions/src/main/resources/config/auth.properties` file.
   For instance, for organizations `spine-examples` and `SpineEventEngine`, enter:
 
 ```properties
-permitted-organizations=spine-examples,SpineEventEngine
+permitted-organizations=spine-examples, SpineEventEngine
 ```
 
 Additionally, ensure that each specified organization has 
@@ -106,8 +106,8 @@ This will start the server on `localhost:50051` and publish the required JAR fil
 for the client application to the Maven Local repository.
 
 4. Configure the client's connection to the server. To do this, 
-  open the `config/server.properties` file in the resources directory of the `desktop` module
-  and enter the server's address and port as follows:
+  enter the server's address and port 
+  in the `desktop/src/main/resources/config/server.properties` file as follows:
 
 ```properties
 server.address=localhost

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -77,7 +77,6 @@ repositories {
 }
 
 kotlin {
-    jvmToolchain(BuildSettings.javaVersion.asInt())
     explicitApi()
 }
 

--- a/desktop/buildSrc/build.gradle.kts
+++ b/desktop/buildSrc/build.gradle.kts
@@ -70,8 +70,17 @@ val dokkaVersion = "1.9.20"
  */
 val composeVersion = "1.6.11"
 
+/**
+ * Checks that the correct version of the JDK is being used.
+ */
+if (JavaVersion.current() < JavaVersion.toVersion(jvmVersion)) {
+    throw GradleException(
+        "JDK $jvmVersion or higher is required for building client application, " +
+                "but JDK ${JavaVersion.current()} is being used."
+    )
+}
+
 kotlin {
-    jvmToolchain(jvmVersion)
     explicitApiWarning()
 }
 

--- a/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
+++ b/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://github.com/spine-examples/Pingh
 public object Pingh {
-    private const val version = "1.0.0-SNAPSHOT.13"
+    private const val version = "1.0.0-SNAPSHOT.14"
     private const val group = "io.spine.examples.pingh"
 
     public const val client: String = "$group:client:$version"

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/PermittedOrganizations.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/PermittedOrganizations.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.pingh.sessions
+
+import io.spine.examples.pingh.github.Organization
+import io.spine.examples.pingh.github.loggedAs
+import java.util.Properties
+
+/**
+ * Organizations whose members are allowed to authorize with the Pingh app.
+ *
+ * For this to work correctly, the organization must have
+ * the [Pingh application](https://github.com/apps/pingh-tracker-of-github-mentions)
+ * installed on GitHub.
+ */
+internal object PermittedOrganizations {
+    /**
+     * List of names of permitted organizations.
+     */
+    private val orgs: Set<Organization> = loadFromProperties()
+
+    /**
+     * Loads the list of permitted organizations from resource folder.
+     */
+    private fun loadFromProperties(): Set<Organization> {
+        val path = "/config/authentication.properties"
+        val properties = Properties()
+        PermittedOrganizations::class.java.getResourceAsStream(path).use {
+            properties.load(it)
+        }
+        val orgStr = properties.getProperty("permitted-organizations")
+            ?: throw IllegalStateException(
+                "List of names of permitted organizations must be provided " +
+                        "in the configuration file located at \"resource$path\"."
+            )
+        return orgStr.split(",")
+            .map { Organization::class.loggedAs(it) }
+            .toSet()
+    }
+
+    /**
+     * Returns `true` if a member of this organization is permitted to log in to the application.
+     */
+    internal fun contains(org: Organization): Boolean = orgs.contains(org)
+}

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/PermittedOrganizations.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/PermittedOrganizations.kt
@@ -47,7 +47,7 @@ internal object PermittedOrganizations {
      * Loads the list of permitted organizations from resource folder.
      */
     private fun loadFromProperties(): Set<Organization> {
-        val path = "/config/authentication.properties"
+        val path = "/config/auth.properties"
         val properties = Properties()
         PermittedOrganizations::class.java.getResourceAsStream(path).use {
             properties.load(it)
@@ -57,8 +57,8 @@ internal object PermittedOrganizations {
                 "List of names of permitted organizations must be provided " +
                         "in the configuration file located at \"resource$path\"."
             )
-        return orgStr.split(",")
-            .map { Organization::class.loggedAs(it) }
+        return orgStr.split(""",\s*""".toRegex())
+            .map { Organization::class.loggedAs(it.trim()) }
             .toSet()
     }
 

--- a/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/UserSessionProcess.kt
+++ b/sessions/src/main/kotlin/io/spine/examples/pingh/sessions/UserSessionProcess.kt
@@ -28,9 +28,7 @@ package io.spine.examples.pingh.sessions
 
 import io.spine.core.External
 import io.spine.examples.pingh.clock.event.TimePassed
-import io.spine.examples.pingh.github.Organization
 import io.spine.examples.pingh.github.PersonalAccessToken
-import io.spine.examples.pingh.github.loggedAs
 import io.spine.examples.pingh.sessions.command.LogUserIn
 import io.spine.examples.pingh.sessions.command.LogUserOut
 import io.spine.examples.pingh.sessions.command.RefreshToken
@@ -48,19 +46,6 @@ import io.spine.server.procman.ProcessManager
 import io.spine.server.tuple.EitherOf2
 import java.util.Optional
 import kotlin.jvm.Throws
-
-/**
- * Organizations whose members are allowed to authorize with the Pingh app.
- *
- * For this to work correctly, the organization must have
- * the [Pingh application](https://github.com/apps/pingh-tracker-of-github-mentions)
- * installed on GitHub.
- */
-private val permittedOrganizations: Set<Organization> = setOf(
-    Organization::class.loggedAs("SpineEventEngine"),
-    Organization::class.loggedAs("TeamDev-Ltd"),
-    Organization::class.loggedAs("TeamDev-IP")
-)
 
 /**
  * Coordinates session management, that is, user login and logout.
@@ -157,12 +142,12 @@ internal class UserSessionProcess :
 
     /**
      * Throws an `NotMemberOfPermittedOrgs` rejection if the user is not a member
-     * of any [permitted organizations][permittedOrganizations].
+     * of any [permitted organizations][PermittedOrganizations].
      */
     @Throws(NotMemberOfPermittedOrgs::class)
     private fun ensureMembershipInPermittedOrgs(token: PersonalAccessToken) {
         val userOrganizations = users.memberships(token)
-        if (!userOrganizations.any { permittedOrganizations.contains(it) }) {
+        if (!userOrganizations.any { PermittedOrganizations.contains(it) }) {
             throw NotMemberOfPermittedOrgs::class.with(state().id)
         }
     }

--- a/sessions/src/main/resources/config/auth.properties
+++ b/sessions/src/main/resources/config/auth.properties
@@ -27,6 +27,6 @@
 # Names of organizations whose members are permitted to authenticate with the Pingh app.
 #
 # Replace these values with the names of authorized organizations,
-# formatted as a comma-separated list without spaces, e.g., `Name1,name2`.
+# formatted as a comma-separated list, e.g., `Name1, name2`.
 #
-permitted-organizations=SpineEventEngine,TeamDev-Ltd,TeamDev-IP
+permitted-organizations=SpineEventEngine, TeamDev-Ltd, TeamDev-IP

--- a/sessions/src/main/resources/config/authentication.properties
+++ b/sessions/src/main/resources/config/authentication.properties
@@ -1,0 +1,32 @@
+#
+# Copyright 2024, TeamDev. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Redistribution and use in source and/or binary forms, with or without
+# modification, must retain the above copyright notice and the following
+# disclaimer.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# Names of organizations whose members are permitted to authenticate with the Pingh app.
+#
+# Replace these values with the names of authorized organizations,
+# formatted as a comma-separated list without spaces, e.g., `Name1,name2`.
+#
+permitted-organizations=SpineEventEngine,TeamDev-Ltd,TeamDev-IP

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of the `Pingh` to publish.
  */
-val pinghVersion: String by extra("1.0.0-SNAPSHOT.13")
+val pinghVersion: String by extra("1.0.0-SNAPSHOT.14")


### PR DESCRIPTION
The changeset introduces several improvements to the project:

1. Enables the client application to be built with JDK 17 and higher, whereas previously only JDK 17 was supported.
2. Moves the list of permitted GitHub organization names for application access to a separate configuration file.
3. Adds a "Testing" section to the `README` documentation.