### PR TITLE
Move initiation of the first mention update from client to server

### DIFF
--- a/client/src/main/kotlin/io/spine/examples/pingh/client/MentionsFlow.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/MentionsFlow.kt
@@ -67,7 +67,6 @@ public class MentionsFlow internal constructor(
 
     init {
         subscribeToMentionsUpdates()
-        updateMentions()
     }
 
     /**

--- a/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
+++ b/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://github.com/spine-examples/Pingh
 public object Pingh {
-    private const val version = "1.0.0-SNAPSHOT.18"
+    private const val version = "1.0.0-SNAPSHOT.19"
     private const val group = "io.spine.examples.pingh"
 
     public const val client: String = "$group:client:$version"

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubClientProcess.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubClientProcess.kt
@@ -112,9 +112,10 @@ internal class GitHubClientProcess :
     /**
      * Starts the process of fetching mentions from GitHub upon the first login.
      *
-     * If no updates have been completed and none are currently in progress,
-     * then no updates have been made yet, and the `UpdateMentionsFromGitHub` command
-     * will be sent. Otherwise, an empty `Optional` will be returned.
+     * If no updates have been completed and none are in progress,
+     * indicating that mentions have not yet been fetched,
+     * an `UpdateMentionsFromGitHub` command will be sent.
+     * Otherwise, an empty `Optional` will be returned.
      */
     @Command
     internal fun on(event: GitHubTokenUpdated): Optional<UpdateMentionsFromGitHub> {

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubClientProcess.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/GitHubClientProcess.kt
@@ -31,6 +31,7 @@ import com.google.protobuf.Timestamp
 import com.google.protobuf.util.Timestamps
 import com.google.protobuf.util.Timestamps.between
 import io.spine.base.EventMessage
+import io.spine.base.Time.currentTime
 import io.spine.core.External
 import io.spine.examples.pingh.clock.event.TimePassed
 import io.spine.examples.pingh.github.Mention
@@ -106,6 +107,21 @@ internal class GitHubClientProcess :
             GitHubClientId::class.of(event.id.username),
             event.token
         )
+    }
+
+    /**
+     * Starts the process of fetching mentions from GitHub upon the first login.
+     *
+     * If no updates have been completed and none are currently in progress,
+     * then no updates have been made yet, and the `UpdateMentionsFromGitHub` command
+     * will be sent. Otherwise, an empty `Optional` will be returned.
+     */
+    @Command
+    internal fun on(event: GitHubTokenUpdated): Optional<UpdateMentionsFromGitHub> {
+        if (!state().hasWhenLastSuccessfullyUpdated() && !state().hasWhenStarted()) {
+            return Optional.of(UpdateMentionsFromGitHub::class.buildBy(event.id, currentTime()))
+        }
+        return Optional.empty()
     }
 
     /**

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of the `Pingh` to publish.
  */
-val pinghVersion: String by extra("1.0.0-SNAPSHOT.18")
+val pinghVersion: String by extra("1.0.0-SNAPSHOT.19")


### PR DESCRIPTION
Previously, two issues were encountered:

1. On the first launch, user mentions sometimes failed to load, necessitating a manual refresh or a lengthy wait for updates.
2. UI tests occasionally failed due to mentions not loading correctly.

Both issues stemmed from a single bug: the initial update request was triggered by the client immediately after login, leading to situations where a client-side update command was processed before the server-side login process was completed. Consequently, the update process couldn’t start immediately and had to wait for the next scheduled or manual update.

This changeset shifts the initiation of the first mention update from the client to the server, ensuring the update occurs only after a successful login.