### PR TITLE
Automate login verification requests in the client application

### DIFF
--- a/client/src/main/kotlin/io/spine/examples/pingh/client/DurationExts.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/DurationExts.kt
@@ -28,16 +28,9 @@ package io.spine.examples.pingh.client
 
 import com.google.protobuf.Duration
 import com.google.protobuf.util.Durations
-import kotlin.time.Duration.Companion.nanoseconds
 
 /**
  * The value of this `Duration` in milliseconds.
  */
 internal val Duration.inWholeMilliseconds: Long
     get() = Durations.toMillis(this)
-
-/**
- * Converts this duration to Kotlin duration.
- */
-internal fun Duration.asKotlinDuration(): kotlin.time.Duration =
-    Durations.toNanos(this).nanoseconds

--- a/client/src/main/kotlin/io/spine/examples/pingh/client/DurationExts.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/DurationExts.kt
@@ -28,9 +28,16 @@ package io.spine.examples.pingh.client
 
 import com.google.protobuf.Duration
 import com.google.protobuf.util.Durations
+import kotlin.time.Duration.Companion.nanoseconds
 
 /**
  * The value of this `Duration` in milliseconds.
  */
 internal val Duration.inWholeMilliseconds: Long
     get() = Durations.toMillis(this)
+
+/**
+ * Converts this duration to Kotlin duration.
+ */
+internal fun Duration.asKotlinDuration(): kotlin.time.Duration =
+    Durations.toNanos(this).nanoseconds

--- a/client/src/main/kotlin/io/spine/examples/pingh/client/ExponentialBackoffStrategy.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/ExponentialBackoffStrategy.kt
@@ -104,13 +104,13 @@ internal class ExponentialBackoffStrategy private constructor(builder: Builder) 
     /**
      * Attempts to perform the [action][retryAction].
      *
-     * If the task completes successfully, execute the [onSuccess()][onSuccess] method
-     * and terminate the strategy.
+     * If the `action` completes successfully, the [onSuccess()][onSuccess] method is executed
+     * and the strategy is terminated.
      *
-     * If the task completes with rejection, only end the strategy.
+     * If the `action` completes with rejection, the strategy ends.
      *
-     * If the task completes unsuccessfully and the execution time has not expired,
-     * the task will be scheduled for re-execution.
+     * If the `action` completes unsuccessfully and the execution time has not expired,
+     * the `action` is scheduled for re-execution.
      */
     private fun tryPerforming() {
         if (countdown!!.isDone) {

--- a/client/src/main/kotlin/io/spine/examples/pingh/client/ExponentialBackoffStrategy.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/ExponentialBackoffStrategy.kt
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.pingh.client
+
+import com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly
+import java.util.concurrent.CompletableFuture
+import kotlin.time.Duration
+import kotlin.time.toJavaDuration
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * A strategy for retrying an action with exponentially increasing intervals
+ * between attempts following each failure.
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Exponential_backoff">
+ *     Exponential backoff algorithm</a>
+ */
+internal class ExponentialBackoffStrategy private constructor(builder: Builder) {
+    /**
+     * An action that must be repeated until it succeeds.
+     */
+    private val retryAction = builder.retryAction!!
+
+    /**
+     * A minimum duration for the repeat interval.
+     */
+    private val minDelay = builder.minDelay!!
+
+    /**
+     * A maximum duration for the repeat interval.
+     */
+    private val maxDelay = builder.maxDelay!!
+
+    /**
+     * An exponential delay increase coefficient.
+     */
+    private var factor = builder.factor!!
+
+    /**
+     * A timeframe in which [action][retryAction] attempts must be retried.
+     */
+    private var limit = builder.limit!!
+
+    /**
+     * An action to execute upon the successful completion of a [repeatable task][retryAction].
+     */
+    private var onSuccess = builder.onSuccess!!
+
+    /**
+     * A time counter that completes when the allotted time for the strategy expires.
+     */
+    private lateinit var countdown: CompletableFuture<Unit>
+
+    /**
+     * A job that asynchronously performs an [action][retryAction] with a [delay][currentDelay].
+     */
+    private lateinit var retryJob: Job
+
+    /**
+     * A current delay time between attempts to execute the [action][retryAction].
+     */
+    private var currentDelay: Duration? = null
+
+    /**
+     * Starts the execution of the exponential backoff strategy.
+     */
+    internal fun start() {
+        currentDelay = minDelay
+        countdown = CompletableFuture.supplyAsync { sleepUninterruptibly(limit.toJavaDuration()) }
+        tryPerforming()
+    }
+
+    /**
+     * Attempts to perform the [action][retryAction].
+     *
+     * If the `action` is completely successful, the strategy execution is completed.
+     * If the `action` fails and the allotted time for the strategy has not expired,
+     * the delay is increased and the action is retried.
+     */
+    private fun tryPerforming() {
+        val res = retryAction()
+        if (res) {
+            onSuccess()
+        } else {
+            val delay = currentDelay!!
+            currentDelay = min(currentDelay!! * factor, maxDelay)
+            println(delay)
+            retryJob = invoke(delay, ::tryPerforming)
+        }
+    }
+
+    /**
+     * Stops all scheduled actions.
+     */
+    internal fun stop() {
+        countdown.cancel(true)
+        if (retryJob.isActive) {
+            retryJob.cancel()
+        }
+    }
+
+    internal companion object {
+        /**
+         * Creates a builder to customize the exponential backoff strategy.
+         */
+        internal fun builder(): Builder = Builder()
+    }
+
+    /**
+     * Builder to customize the exponential backoff strategy.
+     */
+    internal class Builder {
+        /**
+         * An action that must be repeated until it succeeds.
+         */
+        internal var retryAction: (() -> Boolean)? = null
+            private set
+
+        /**
+         * A minimum duration for the repeat interval.
+         */
+        internal var minDelay: Duration? = null
+            private set
+
+        /**
+         * A maximum duration for the repeat interval.
+         */
+        internal var maxDelay: Duration? = null
+            private set
+
+        /**
+         * An exponential delay increase coefficient.
+         */
+        internal var factor: Double? = null
+            private set
+
+        /**
+         * A timeframe in which [action][retryAction] attempts must be retried.
+         */
+        internal var limit: Duration? = null
+            private set
+
+        /**
+         * An action to execute upon the successful completion of a [repeatable task][retryAction].
+         */
+        internal var onSuccess: (() -> Unit)? = null
+            private set
+
+        /**
+         * Sets the action that must be repeated until it succeeds.
+         *
+         * @param retryAction Returns `true` if successful.
+         */
+        internal fun perform(retryAction: () -> Boolean): Builder {
+            this.retryAction = retryAction
+            return this
+        }
+
+        /**
+         * Sets the minimum repetition interval.
+         */
+        internal fun withMinDelay(minDelay: Duration): Builder {
+            this.minDelay = minDelay
+            return this
+        }
+
+        /**
+         * Sets the maximum repetition interval.
+         */
+        internal fun withMaxDelay(maxDelay: Duration): Builder {
+            this.maxDelay = maxDelay
+            return this
+        }
+
+        /**
+         * Sets the exponential delay increase coefficient.
+         */
+        internal fun withFactor(factor: Double): Builder {
+            this.factor = factor
+            return this
+        }
+
+        /**
+         * Sets the timeframe in which [action][retryAction] attempts must be retried.
+         */
+        internal fun withTimeLimit(limit: Duration): Builder {
+            this.limit = limit
+            return this
+        }
+
+        /**
+         * Sets the action to execute upon the successful completion
+         * of a [repeatable task][retryAction].
+         */
+        internal fun doOnSuccess(action: () -> Unit): Builder {
+            onSuccess = action
+            return this
+        }
+
+        /**
+         * Creates a configured [ExponentialBackoffStrategy].
+         *
+         * @throws IllegalStateException if some strategy data is missing.
+         */
+        internal fun build(): ExponentialBackoffStrategy {
+            checkNotNull(retryAction) {
+                "The action to be performed during the strategy must be defined."
+            }
+            checkNotNull(minDelay) { "The minimum repetition interval must be specified." }
+            checkNotNull(maxDelay) { "The maximum repetition interval must be specified." }
+            checkNotNull(factor) { "The exponential delay increase coefficient must be specified." }
+            checkNotNull(limit) { "The duration of the strategy must be defined." }
+            checkNotNull(onSuccess) {
+                "The action to execute upon the successful completion " +
+                        "of the strategy must be defined."
+            }
+            return ExponentialBackoffStrategy(this)
+        }
+    }
+}
+
+/**
+ * Asynchronously performs work with a delay.
+ */
+private fun invoke(delay: Duration, action: () -> Unit): Job =
+    CoroutineScope(Dispatchers.Default).launch {
+        delay(delay)
+        action()
+    }
+
+/**
+ * Returns the minimum duration.
+ */
+private fun min(d1: Duration, d2: Duration): Duration =
+    if (d1.inWholeNanoseconds < d2.inWholeNanoseconds) d1 else d2

--- a/client/src/main/kotlin/io/spine/examples/pingh/client/ExponentialBackoffStrategy.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/ExponentialBackoffStrategy.kt
@@ -27,8 +27,10 @@
 package io.spine.examples.pingh.client
 
 import com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly
+import com.google.protobuf.util.Durations
 import java.util.concurrent.CompletableFuture
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.toJavaDuration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -217,16 +219,16 @@ internal class ExponentialBackoffStrategy private constructor(builder: Builder) 
         /**
          * Sets the minimum repetition interval.
          */
-        internal fun withMinDelay(minDelay: Duration): Builder {
-            this.minDelay = minDelay
+        internal fun withMinDelay(minDelay: com.google.protobuf.Duration): Builder {
+            this.minDelay = minDelay.toKotlin()
             return this
         }
 
         /**
          * Sets the maximum repetition interval.
          */
-        internal fun withMaxDelay(maxDelay: Duration): Builder {
-            this.maxDelay = maxDelay
+        internal fun withMaxDelay(maxDelay: com.google.protobuf.Duration): Builder {
+            this.maxDelay = maxDelay.toKotlin()
             return this
         }
 
@@ -241,8 +243,8 @@ internal class ExponentialBackoffStrategy private constructor(builder: Builder) 
         /**
          * Sets the timeframe in which [action][retryAction] attempts must be retried.
          */
-        internal fun withTimeLimit(limit: Duration): Builder {
-            this.limit = limit
+        internal fun withTimeLimit(limit: com.google.protobuf.Duration): Builder {
+            this.limit = limit.toKotlin()
             return this
         }
 
@@ -285,6 +287,12 @@ private fun invoke(delay: Duration, action: () -> Unit): Job =
         delay(delay)
         action()
     }
+
+/**
+ * Converts this duration to Kotlin duration.
+ */
+private fun com.google.protobuf.Duration.toKotlin(): Duration =
+    Durations.toNanos(this).nanoseconds
 
 /**
  * Returns the minimum duration.

--- a/client/src/main/kotlin/io/spine/examples/pingh/client/LoginFlow.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/LoginFlow.kt
@@ -115,4 +115,13 @@ public class LoginFlow internal constructor(
             }
         }
     }
+
+    /**
+     * Cancels any processes initiated during this stage of flow.
+     */
+    internal fun close() {
+        when (val screenStage = stage.value) {
+            is VerifyLogin -> screenStage.close()
+        }
+    }
 }

--- a/client/src/main/kotlin/io/spine/examples/pingh/client/PinghApplication.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/PinghApplication.kt
@@ -92,6 +92,11 @@ public class PinghApplication private constructor(
     private var mentionsFlow: MentionsFlow? = null
 
     /**
+     * Describes the login to GitHub via GitHub's device flow.
+     */
+    private var loginFlow: LoginFlow? = null
+
+    /**
      * Flow that manages the sending of notifications within the app.
      */
     private val notificationsFlow = NotificationsFlow(notificationSender, settings)
@@ -129,9 +134,13 @@ public class PinghApplication private constructor(
     public fun isLoggedIn(): Boolean = session.value != null
 
     /**
-     * Initiates the login flow.
+     * Initiates the login flow and terminates any previous flow, if it exists.
      */
-    public fun startLoginFlow(): LoginFlow = LoginFlow(client, session)
+    public fun startLoginFlow(): LoginFlow  {
+        loginFlow?.close()
+        loginFlow = LoginFlow(client, session)
+        return loginFlow!!
+    }
 
     /**
      * Returns mentions flow for current session.
@@ -154,6 +163,7 @@ public class PinghApplication private constructor(
      * Closes the client.
      */
     public fun close() {
+        loginFlow?.close()
         sessionObservation.cancel()
         client.close()
         channel.shutdown()

--- a/client/src/test/kotlin/io/spine/examples/pingh/client/e2e/PersonalInteractionIgTest.kt
+++ b/client/src/test/kotlin/io/spine/examples/pingh/client/e2e/PersonalInteractionIgTest.kt
@@ -84,7 +84,7 @@ internal class PersonalInteractionIgTest : IntegrationTest() {
         val loginFlow = app().startLoginFlow()
         (loginFlow.currentStage().value as EnterUsername).requestUserCode(username) {
             enterUserCode()
-            (loginFlow.currentStage().value as VerifyLogin).confirm(
+            (loginFlow.currentStage().value as VerifyLogin).waitForAuthCompletion(
                 onSuccess = {
                     future.complete(null)
                 }

--- a/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
+++ b/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://github.com/spine-examples/Pingh
 public object Pingh {
-    private const val version = "1.0.0-SNAPSHOT.19"
+    private const val version = "1.0.0-SNAPSHOT.20"
     private const val group = "io.spine.examples.pingh"
 
     public const val client: String = "$group:client:$version"

--- a/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/CountdownTimer.kt
+++ b/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/CountdownTimer.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -71,7 +72,7 @@ internal fun CountdownTimer(
 ) {
     require(minutes >= 0) { "The number of minutes must be non-negative." }
     require(seconds >= 0) { "The number of seconds must be non-negative." }
-    val fullTime = TimeUnit(minutes, seconds)
+    val fullTime = remember { TimeUnit(minutes, seconds) }
     val time by produceState(initialValue = fullTime) {
         while (value.inWholeSeconds > 0) {
             delay(1.seconds)

--- a/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/CountdownTimer.kt
+++ b/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/CountdownTimer.kt
@@ -72,8 +72,12 @@ internal fun CountdownTimer(
     indicatorColor: Color,
     trackColor: Color
 ) {
-    require(minutes >= 0) { "The number of minutes must be non-negative." }
-    require(seconds >= 0) { "The number of seconds must be non-negative." }
+    require(minutes >= 0) {
+        "The number of minutes must be non-negative, but `$minutes` was provided."
+    }
+    require(seconds >= 0) {
+        "The number of seconds must be non-negative, but `$seconds` was provided."
+    }
     val total = remember { minutes * secPerMin + seconds }
     val left by produceState(initialValue = total) {
         while (value > 0) {

--- a/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/CountdownTimer.kt
+++ b/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/CountdownTimer.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.pingh.desktop
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.unit.Dp
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
+
+/**
+ * Displays a countdown timer that updates every second, starting from "`minutes`:`seconds`"
+ * and ending at "00:00".
+ *
+ * The timer includes two components:
+ *
+ * 1. A circular progress indicator that visually represents the time left.
+ * 2. A text displaying the exact time remaining in `mm:ss` format.
+ *
+ * The timer starts automatically when the component enters the composition
+ * and stops when it exits.
+ *
+ * @param minutes The number of minutes to count down.
+ * @param seconds The number of seconds to count down.
+ * @param size The timer size.
+ * @param indicatorColor The color of this progress indicator.
+ * @param trackColor The color of the track behind the indicator.
+ */
+@Composable
+internal fun CountdownTimer(
+    minutes: Int,
+    seconds: Int,
+    size: Dp,
+    indicatorColor: Color,
+    trackColor: Color
+) {
+    require(minutes >= 0) { "The number of minutes must be non-negative." }
+    require(seconds >= 0) { "The number of seconds must be non-negative." }
+    val fullTime = TimeUnit(minutes, seconds)
+    val time by produceState(initialValue = fullTime) {
+        while (value.inWholeSeconds > 0) {
+            delay(1.seconds)
+            value = value.minusSecond()
+        }
+    }
+    Box(
+        modifier = Modifier.size(size),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator(
+            progress = { time.inWholeSeconds.toFloat() / fullTime.inWholeSeconds },
+            modifier = Modifier.fillMaxSize(),
+            color = indicatorColor,
+            trackColor = trackColor,
+            strokeCap = StrokeCap.Round
+        )
+        Text(
+            text = "$time",
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
+}
+
+
+
+/**
+ * A time representation in minutes and seconds for use in countdown timers.
+ */
+private data class TimeUnit(val min: Int, val sec: Int) {
+
+    val inWholeSeconds: Int
+        get() = min * secPerMin + sec
+
+    @Suppress("MagicNumber" /* Uses for ensure "mm:ss" time format. */)
+    override fun toString(): String {
+        val mins = if (min < 10) "0$min" else "$min"
+        val secs = if (sec < 10) "0$sec" else "$sec"
+        return "$mins:$secs"
+    }
+
+    fun minusSecond(): TimeUnit {
+        check(inWholeSeconds > 0) { "Time has already elapsed." }
+        val nextSec = sec - 1
+        return if (nextSec < 0) {
+             TimeUnit(min - 1, secPerMin - 1)
+        } else {
+            TimeUnit(min, nextSec)
+        }
+    }
+
+    private companion object {
+        private const val secPerMin = 60
+    }
+}

--- a/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/CountdownTimer.kt
+++ b/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/CountdownTimer.kt
@@ -90,13 +90,11 @@ internal fun CountdownTimer(
             strokeCap = StrokeCap.Round
         )
         Text(
-            text = "$time",
+            text = time.toString(),
             style = MaterialTheme.typography.bodyLarge
         )
     }
 }
-
-
 
 /**
  * A time representation in minutes and seconds for use in countdown timers.
@@ -106,7 +104,7 @@ private data class TimeUnit(val min: Int, val sec: Int) {
     val inWholeSeconds: Int
         get() = min * secPerMin + sec
 
-    @Suppress("MagicNumber" /* Uses for ensure "mm:ss" time format. */)
+    @Suppress("MagicNumber" /* Uses for ensuring "mm:ss" time format. */)
     override fun toString(): String {
         val mins = if (min < 10) "0$min" else "$min"
         val secs = if (sec < 10) "0$sec" else "$sec"

--- a/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/DurationExts.kt
+++ b/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/DurationExts.kt
@@ -33,15 +33,13 @@ private const val secPerMin = 60
 private const val minPerHour = 60
 
 /**
- * Returns the number of minutes in this duration.
- *
- * @return The number of minutes, from 0 to 59 inclusive.
+ * Minutes of hour of the duration, ranging from 0 to 59.
  */
-internal fun Duration.minutes(): Int = (Durations.toMinutes(this) % minPerHour).toInt()
+internal val Duration.minutesOfHour: Int
+    get() = (Durations.toMinutes(this) % minPerHour).toInt()
 
 /**
- * Returns the number of seconds in this duration.
- *
- * @return The number of seconds, from 0 to 59 inclusive.
+ * Seconds of minute of the duration, ranging from 0 to 59.
  */
-internal fun Duration.seconds(): Int = (Durations.toSeconds(this) % secPerMin).toInt()
+internal val Duration.secondsOfMinute: Int
+    get() = (Durations.toSeconds(this) % secPerMin).toInt()

--- a/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/DurationExts.kt
+++ b/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/DurationExts.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.pingh.desktop
+
+import com.google.protobuf.Duration
+import com.google.protobuf.util.Durations
+
+/**
+ * Returns the number of minutes in this duration.
+ *
+ * @return The number of minutes, from 0 to 59 inclusive.
+ */
+internal fun Duration.minutes(): Int = (Durations.toMinutes(this) % 60).toInt()
+
+/**
+ * Returns the number of seconds in this duration.
+ *
+ * @return The number of seconds, from 0 to 59 inclusive.
+ */
+internal fun Duration.seconds(): Int = (Durations.toSeconds(this) % 60).toInt()

--- a/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/DurationExts.kt
+++ b/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/DurationExts.kt
@@ -29,16 +29,19 @@ package io.spine.examples.pingh.desktop
 import com.google.protobuf.Duration
 import com.google.protobuf.util.Durations
 
+private const val secPerMin = 60
+private const val minPerHour = 60
+
 /**
  * Returns the number of minutes in this duration.
  *
  * @return The number of minutes, from 0 to 59 inclusive.
  */
-internal fun Duration.minutes(): Int = (Durations.toMinutes(this) % 60).toInt()
+internal fun Duration.minutes(): Int = (Durations.toMinutes(this) % minPerHour).toInt()
 
 /**
  * Returns the number of seconds in this duration.
  *
  * @return The number of seconds, from 0 to 59 inclusive.
  */
-internal fun Duration.seconds(): Int = (Durations.toSeconds(this) % 60).toInt()
+internal fun Duration.seconds(): Int = (Durations.toSeconds(this) % secPerMin).toInt()

--- a/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/Login.kt
+++ b/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/Login.kt
@@ -450,7 +450,7 @@ private fun VerificationPage(
             Spacer(Modifier.height(5.dp))
             CodeExpiredErrorMessage(flow)
         } else {
-            VerificationInfo(
+            VerifyLoginSection(
                 verificationUrl = verificationUrl,
                 expiresIn = expiresIn
             )
@@ -567,7 +567,7 @@ private fun CodeExpiredErrorMessage(flow: VerifyLogin) {
  * @param expiresIn The duration after which the `userCode` expires.
  */
 @Composable
-private fun VerificationInfo(
+private fun VerifyLoginSection(
     verificationUrl: Url,
     expiresIn: Duration
 ) {
@@ -577,8 +577,8 @@ private fun VerificationInfo(
         horizontalArrangement = Arrangement.spacedBy(15.dp)
     ) {
         CountdownTimer(
-            minutes = expiresIn.minutes(),
-            seconds = expiresIn.seconds(),
+            minutes = expiresIn.minutesOfHour,
+            seconds = expiresIn.secondsOfMinute,
             size = 55.dp,
             indicatorColor = MaterialTheme.colorScheme.primary,
             trackColor = MaterialTheme.colorScheme.background

--- a/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/Login.kt
+++ b/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/Login.kt
@@ -501,7 +501,8 @@ private fun UserCodeField(
                     )
                 }
             }
-            .padding(horizontal = 15.dp),
+            .padding(horizontal = 15.dp)
+            .testTag("user-code"),
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/desktop/src/test/kotlin/io/spine/examples/pingh/desktop/LoginPageUiTest.kt
+++ b/desktop/src/test/kotlin/io/spine/examples/pingh/desktop/LoginPageUiTest.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.runComposeUiTest
 import io.spine.examples.pingh.desktop.given.DelayedFactAssertion.Companion.awaitFact
-import io.spine.examples.pingh.desktop.given.delay
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.seconds
 import org.junit.jupiter.api.DisplayName
@@ -52,11 +51,8 @@ internal class LoginPageUiTest : UiTest() {
     private val SemanticsNodeInteractionsProvider.usernameInput
         get() = onNodeWithTag("username-input")
 
-    private val SemanticsNodeInteractionsProvider.submitButton
-        get() = onNodeWithTag("submit-button")
-
-    private val SemanticsNodeInteractionsProvider.noResponseMessage
-        get() = onNodeWithTag("no-response-message")
+    private val SemanticsNodeInteractionsProvider.userCode
+        get() = onNodeWithTag("user-code")
 
     @Test
     internal fun `have login button enabled only when a valid username is entered`() =
@@ -71,30 +67,13 @@ internal class LoginPageUiTest : UiTest() {
         }
 
     @Test
-    internal fun `have submit button disabled after it is clicked, if no code has been entered`() =
+    internal fun `be replaced with the Mentions page when the user code is entered`() =
         runComposeUiTest {
             runApp()
             toVerificationPage()
-            submitButton.assertIsEnabled()
-            noResponseMessage.assertDoesNotExist()
-            submitButton.performClick()
-            awaitFact {
-                submitButton.assertIsNotEnabled()
-                noResponseMessage.assertExists()
-            }
-        }
-
-    @Test
-    internal fun `have submit button become available again 5 seconds after unsuccessful click`() =
-        runComposeUiTest {
-            runApp()
-            toVerificationPage()
-            submitButton.performClick()
-            delay(5.seconds)
-            awaitFact {
-                submitButton.assertIsEnabled()
-                noResponseMessage.assertDoesNotExist()
-            }
+            awaitFact { userCode.assertExists() }
+            enterUserCode()
+            awaitFact(10.seconds) { userCode.assertDoesNotExist() }
         }
 
     private fun ComposeUiTest.toVerificationPage() {
@@ -103,7 +82,7 @@ internal class LoginPageUiTest : UiTest() {
         loginButton.performClick()
         awaitFact {
             loginButton.assertDoesNotExist()
-            submitButton.assertExists()
+            userCode.assertExists()
         }
     }
 }

--- a/desktop/src/test/kotlin/io/spine/examples/pingh/desktop/SettingsPageUiTest.kt
+++ b/desktop/src/test/kotlin/io/spine/examples/pingh/desktop/SettingsPageUiTest.kt
@@ -54,6 +54,7 @@ internal class SettingsPageUiTest : UiTest() {
         runComposeUiTest {
             runApp()
             logIn()
+            awaitFact { settingsButton.assertExists() }
             settingsButton.performClick()
             awaitFact { dndOption.assertExists() }
             dndOption.performClick()
@@ -61,6 +62,7 @@ internal class SettingsPageUiTest : UiTest() {
             logoutButton.performClick()
             awaitFact { logoutButton.assertDoesNotExist() }
             logIn()
+            awaitFact { settingsButton.assertExists() }
             settingsButton.performClick()
             awaitFact { dndOption.assertIsOn() }
         }

--- a/desktop/src/test/kotlin/io/spine/examples/pingh/desktop/UiTest.kt
+++ b/desktop/src/test/kotlin/io/spine/examples/pingh/desktop/UiTest.kt
@@ -82,12 +82,9 @@ internal abstract class UiTest : IntegrationTest() {
      */
     @OptIn(ExperimentalTestApi::class)
     protected fun ComposeUiTest.logIn() {
+        enterUserCode()
         onNodeWithTag("username-input").performTextInput(username)
         awaitFact { onNodeWithTag("login-button").assertIsEnabled() }
         onNodeWithTag("login-button").performClick()
-        awaitFact { onNodeWithTag("submit-button").assertExists() }
-        enterUserCode()
-        onNodeWithTag("submit-button").performClick()
-        awaitFact { onNodeWithTag("submit-button").assertDoesNotExist() }
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of the `Pingh` to publish.
  */
-val pinghVersion: String by extra("1.0.0-SNAPSHOT.19")
+val pinghVersion: String by extra("1.0.0-SNAPSHOT.20")


### PR DESCRIPTION
Previously, users needed to click a confirmation button to complete the login verification step, which triggered a server request to check if the user code had been entered on GitHub.

This changeset introduces an automated mechanism for sending login verification requests to the Pingh server, eliminating the need for direct user action.

These requests use an exponential backoff strategy, with intervals between requests increasing over time. Requests are sent only when the user is on the Login verification page.

The design of the Login verification page is also updated:

<img width="447" alt="Screenshot 2024-11-06 at 17 49 04" src="https://github.com/user-attachments/assets/0317e3af-aa33-4e41-8287-e366f50378a1">