### PR TITLE
Remove duplication of mentions

### DIFF
--- a/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
+++ b/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://github.com/spine-examples/Pingh
 public object Pingh {
-    private const val version = "1.0.0-SNAPSHOT.26"
+    private const val version = "1.0.0-SNAPSHOT.27"
     private const val group = "io.spine.examples.pingh"
 
     public const val client: String = "$group:client:$version"

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/RemoteGitHubSearch.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/RemoteGitHubSearch.kt
@@ -181,9 +181,9 @@ public class RemoteGitHubSearch(engine: HttpClientEngine) : GitHubSearch {
                 .setTitle(item.title)
                 .get()
             item.takeIf { it.body.contains(user.tag()) }
-                ?.run { Mention::class.from(this) }
+                ?.let { Mention::class.from(it) }
                 ?.takeIf { it.whenMentioned > updatedAfter }
-                ?.run { mentions + this }
+                ?.let { mentions + it }
                 ?: mentions
         }.toSet()
 }

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/RemoteGitHubSearch.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/RemoteGitHubSearch.kt
@@ -126,7 +126,7 @@ public class RemoteGitHubSearch(engine: HttpClientEngine) : GitHubSearch {
             page++
             items += searchIssuesOrPullRequests(token, updatedAfter, itemType, page).itemList
         }
-        return items.filterMentions(username, token, itemType)
+        return items.filterMentions(username, token, updatedAfter, itemType)
     }
 
     /**
@@ -169,6 +169,7 @@ public class RemoteGitHubSearch(engine: HttpClientEngine) : GitHubSearch {
     private fun Set<IssueOrPullRequestFragment>.filterMentions(
         user: Username,
         token: PersonalAccessToken,
+        updatedAfter: Timestamp,
         itemType: ItemType
     ): Set<Mention> =
         this.flatMap { item ->
@@ -176,6 +177,7 @@ public class RemoteGitHubSearch(engine: HttpClientEngine) : GitHubSearch {
                 .findMentionsOn(item.repo(), item.number, itemType)
                 .of(user)
                 .with(token)
+                .by(updatedAfter)
                 .setTitle(item.title)
                 .get()
             if (item.body.contains(user.tag())) {
@@ -340,6 +342,12 @@ private class MentionsOnIssueOrPullRequestsBuilder(
     private var token: PersonalAccessToken? = null
 
     /**
+     * The time after which GitHub items containing the searched mentions
+     * should have been updated.
+     */
+    private var updatedAfter: Timestamp? = null
+
+    /**
      * The string to be used as the title for the found mentions.
      *
      * It is recommended to use the title of the GitHub item where
@@ -364,6 +372,15 @@ private class MentionsOnIssueOrPullRequestsBuilder(
     }
 
     /**
+     * Sets the time after which GitHub items containing the searched mentions
+     * should have been updated.
+     */
+    fun by(updatedAfter: Timestamp): MentionsOnIssueOrPullRequestsBuilder {
+        this.updatedAfter = updatedAfter
+        return this
+    }
+
+    /**
      * Sets the string to be used as the title for the found mentions.
      */
     fun setTitle(title: String): MentionsOnIssueOrPullRequestsBuilder {
@@ -383,6 +400,10 @@ private class MentionsOnIssueOrPullRequestsBuilder(
             "The name of the user whose mentions are to be found is not specified."
         }
         checkNotNull(token) { "The the user authentication token on GitHub is not specified." }
+        checkNotNull(updatedAfter) {
+            "The time after which GitHub items containing the searched mentions " +
+                    "should have been updated is not specified."
+        }
         checkNotNull(title) { "The title for the found mentions is not specified." }
         return comments(issueCommentsUrl) + when (itemType) {
             ItemType.ISSUE -> emptySet()
@@ -400,6 +421,7 @@ private class MentionsOnIssueOrPullRequestsBuilder(
             .itemList
             .filter { comment -> comment.body.contains(user!!.tag()) }
             .map { comment -> Mention::class.from(comment, title!!) }
+            .filter { comments -> comments.whenMentioned > updatedAfter!! }
             .toSet()
 
     /**
@@ -412,6 +434,7 @@ private class MentionsOnIssueOrPullRequestsBuilder(
             .itemList
             .filter { review -> review.body.contains(user!!.tag()) }
             .map { review -> Mention::class.from(review, title!!) }
+            .filter { review -> review.whenMentioned > updatedAfter!! }
             .toSet()
 
     /**

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/RemoteGitHubSearch.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/RemoteGitHubSearch.kt
@@ -180,11 +180,11 @@ public class RemoteGitHubSearch(engine: HttpClientEngine) : GitHubSearch {
                 .by(updatedAfter)
                 .setTitle(item.title)
                 .get()
-            if (item.body.contains(user.tag())) {
-                mentions.plus(Mention::class.from(item))
-            } else {
-                mentions
-            }
+            item.takeIf { it.body.contains(user.tag()) }
+                ?.run { Mention::class.from(this) }
+                ?.takeIf { it.whenMentioned > updatedAfter }
+                ?.run { mentions + this }
+                ?: mentions
         }.toSet()
 }
 

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/TimestampExts.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/TimestampExts.kt
@@ -45,3 +45,8 @@ internal fun Timestamp.add(duration: Duration): Timestamp = Timestamps.add(this,
  * Returns `true` if this value is the default for `Timestamp`; otherwise, returns `false`.
  */
 internal fun Timestamp.isDefault(): Boolean = compare(this, this.defaultInstanceForType) == 0
+
+/**
+ * Compares this `Timestamp` with the passed one.
+ */
+internal operator fun Timestamp.compareTo(other: Timestamp): Int = compare(this, other)

--- a/mentions/src/test/kotlin/io/spine/examples/pingh/mentions/RemoteGitHubSearchSpec.kt
+++ b/mentions/src/test/kotlin/io/spine/examples/pingh/mentions/RemoteGitHubSearchSpec.kt
@@ -26,6 +26,7 @@
 
 package io.spine.examples.pingh.mentions
 
+import com.google.protobuf.util.Timestamps
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
@@ -40,6 +41,8 @@ import io.spine.testing.TestValues.randomString
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 @DisplayName("`RemoteGitHubSearch` should")
 internal class RemoteGitHubSearchSpec {
@@ -57,6 +60,16 @@ internal class RemoteGitHubSearchSpec {
         val service = RemoteGitHubSearch(mockEngineThatContainsMentions(token))
         val mentions = service.searchMentions(username, token)
         val expected = expectedMentions()
+        mentions shouldBe expected
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["2024-01-01T00:00:00Z", "2024-05-16T08:35:04Z", "2024-12-31T23:59:59Z"])
+    internal fun `fetch only new mentions, ignoring those already received`(time: String) {
+        val service = RemoteGitHubSearch(mockEngineThatContainsMentions(token))
+        val updateAfter = Timestamps.parse(time)
+        val mentions = service.searchMentions(username, token, updateAfter)
+        val expected = expectedMentions().filter { it.whenMentioned > updateAfter }.toSet()
         mentions shouldBe expected
     }
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of the `Pingh` to publish.
  */
-val pinghVersion: String by extra("1.0.0-SNAPSHOT.26")
+val pinghVersion: String by extra("1.0.0-SNAPSHOT.27")


### PR DESCRIPTION
Previously, some mentions were duplicated due to two bugs, both of which are fixed in this changeset.

1. To prevent duplicates, the `updatedAfter` parameter is used to specify the time after which GitHub items containing the relevant mentions should have been updated, ensuring that previously retrieved mentions are not fetched again. However, this filter was not applied when fetching issue comments, reviews, or review comments. As a result, every time mentions were retrieved from issues or pull requests, all mentions in comments, reviews, and review comments were reloaded.

Now, the `updatedAfter` filter is also applied when retrieving mentions from comments, reviews and review comments.

2. GitHub search is used to fetch mentions, identifying issues and pull requests where mentions have occurred. Previously, when a mention was found in an issue or pull request, it was always added to the list of new mentions. This was incorrect, as mentions should have been filtered using the `updatedAfter` parameter.

Now, when a mention is found in the body of an issue or pull request, it is added only once.