### PR TITLE
Save the login process when minimizing and reopening the application from the system tray

### DIFF
--- a/client/src/main/kotlin/io/spine/examples/pingh/client/LoginFlow.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/LoginFlow.kt
@@ -38,9 +38,7 @@ import kotlinx.coroutines.flow.StateFlow
  *   If it is `Unit`, it means the stage produces no result.
  */
 @Suppress("UnnecessaryAbstractClass" /* Avoids creating instances; only for inheritance. */)
-public abstract class LoginStage<T>(
-    private val isFinal: Boolean = false
-) {
+public abstract class LoginStage<T> {
     /**
      * The result of executing this stage.
      *
@@ -82,7 +80,7 @@ public class LoginFlow internal constructor(
     public fun currentStage(): StateFlow<LoginStage<*>> = stage
 
     /**
-     * Whether the login process is completed.
+     * Return `true` if login process is completed.
      */
     public fun isCompleted(): Boolean = stage.value is LoginCompleted
 

--- a/client/src/main/kotlin/io/spine/examples/pingh/client/LoginFlow.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/LoginFlow.kt
@@ -80,7 +80,7 @@ public class LoginFlow internal constructor(
     public fun currentStage(): StateFlow<LoginStage<*>> = stage
 
     /**
-     * Returns `true` if login process is completed.
+     * Returns `true` if the login process is completed.
      */
     public fun isCompleted(): Boolean = stage.value is LoginCompleted
 
@@ -134,7 +134,7 @@ public class LoginFlow internal constructor(
 }
 
 /**
- * The terminal state of the login,
+ * The terminal stage of the login process,
  * signifying that the login process has been successfully completed.
  */
 private class LoginCompleted : LoginStage<Unit>()

--- a/client/src/main/kotlin/io/spine/examples/pingh/client/LoginFlow.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/LoginFlow.kt
@@ -80,7 +80,7 @@ public class LoginFlow internal constructor(
     public fun currentStage(): StateFlow<LoginStage<*>> = stage
 
     /**
-     * Return `true` if login process is completed.
+     * Returns `true` if login process is completed.
      */
     public fun isCompleted(): Boolean = stage.value is LoginCompleted
 
@@ -134,7 +134,7 @@ public class LoginFlow internal constructor(
 }
 
 /**
- * The final state of the login,
- * indicating that the login process has been successfully completed.
+ * The terminal state of the login,
+ * signifying that the login process has been successfully completed.
  */
 private class LoginCompleted : LoginStage<Unit>()

--- a/client/src/main/kotlin/io/spine/examples/pingh/client/PinghApplication.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/PinghApplication.kt
@@ -159,8 +159,9 @@ public class PinghApplication private constructor(
      * Initiates the login flow and terminates any previous flow, if it exists.
      */
     public fun startLoginFlow(): LoginFlow {
-        loginFlow?.close()
-        loginFlow = LoginFlow(client, ::establishSession)
+        if (loginFlow == null || loginFlow!!.isCompleted()) {
+            loginFlow = LoginFlow(client, ::establishSession)
+        }
         return loginFlow!!
     }
 

--- a/client/src/main/kotlin/io/spine/examples/pingh/client/VerifyLogin.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/VerifyLogin.kt
@@ -68,7 +68,7 @@ public class VerifyLogin internal constructor(
     private val establishSession: (SessionId) -> Unit,
     private val moveToNextStage: () -> Unit,
     event: UserCodeReceived
-) : LoginStage<String>() {
+) : LoginStage<String>(isFinal = true) {
 
     /**
      * The code a user needs to enter on GitHub to confirm login to the app.
@@ -170,6 +170,7 @@ public class VerifyLogin internal constructor(
             EventObserver(command.id, UserLoggedIn::class) {
                 codeExpirationJob.cancel()
                 establishSession(session)
+                completeProcess()
                 future.complete(ActionOutcome.Success)
             },
             EventObserver(command.id, UserIsNotLoggedIntoGitHub::class) {

--- a/client/src/main/kotlin/io/spine/examples/pingh/client/VerifyLogin.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/VerifyLogin.kt
@@ -68,7 +68,7 @@ public class VerifyLogin internal constructor(
     private val establishSession: (SessionId) -> Unit,
     private val moveToNextStage: () -> Unit,
     event: UserCodeReceived
-) : LoginStage<String>(isFinal = true) {
+) : LoginStage<String>() {
 
     /**
      * The code a user needs to enter on GitHub to confirm login to the app.
@@ -170,7 +170,7 @@ public class VerifyLogin internal constructor(
             EventObserver(command.id, UserLoggedIn::class) {
                 codeExpirationJob.cancel()
                 establishSession(session)
-                completeProcess()
+                moveToNextStage()
                 future.complete(ActionOutcome.Success)
             },
             EventObserver(command.id, UserIsNotLoggedIntoGitHub::class) {

--- a/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
+++ b/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://github.com/spine-examples/Pingh
 public object Pingh {
-    private const val version = "1.0.0-SNAPSHOT.27"
+    private const val version = "1.0.0-SNAPSHOT.28"
     private const val group = "io.spine.examples.pingh"
 
     public const val client: String = "$group:client:$version"

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of the `Pingh` to publish.
  */
-val pinghVersion: String by extra("1.0.0-SNAPSHOT.27")
+val pinghVersion: String by extra("1.0.0-SNAPSHOT.28")


### PR DESCRIPTION
Previously, minimizing the application and reopening it from the system tray would reset the login process, returning the user to the name entry page.

This issue arose because reopening the window triggered a re-render of all elements, resulting in a login flow being requested. As a result, the existing login session was terminated, and a new one was initiated.

This changeset resolves the issue. When a login flow is received by client, a check is performed to determine its status: if the login process has not started or the previous one has already completed, a new login flow is returned; otherwise, the existing flow is reused. This allows users to preserve their login progress when minimizing and reopening the application from the tray.