### PR TITLE
Hide the application window when it loses focus

### DIFF
--- a/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
+++ b/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://github.com/spine-examples/Pingh
 public object Pingh {
-    private const val version = "1.0.0-SNAPSHOT.32"
+    private const val version = "1.0.0-SNAPSHOT.33"
     private const val group = "io.spine.examples.pingh"
 
     public const val client: String = "$group:client:$version"

--- a/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/Window.kt
+++ b/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/Window.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -47,8 +48,10 @@ import androidx.compose.ui.window.Window as ComposeWindow
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.rememberWindowState
 import io.spine.examples.pingh.client.PinghApplication
+import java.awt.Desktop
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
+import javax.swing.SwingUtilities
 
 /**
  * Displays Pingh platform window.
@@ -101,17 +104,35 @@ private fun PlatformWindow(
     ) {
         content()
 
-        // Hides the window if you focus from it.
         DisposableEffect(window) {
+            // Focuses on the window and brings it to the front when displayed.
             val listener = object : WindowAdapter() {
+                override fun windowActivated(e: WindowEvent?) {
+                    SwingUtilities.invokeLater {
+                        window.requestFocus()
+                    }
+                }
+            }
+            window.addWindowListener(listener)
+
+            // Hides the window if you focus from it.
+            val focusListener = object : WindowAdapter() {
                 override fun windowLostFocus(e: WindowEvent?) {
                     state.isShown = false
                 }
             }
-            window.addWindowFocusListener(listener)
+            window.addWindowFocusListener(focusListener)
+
             onDispose {
-                window.removeWindowFocusListener(listener)
+                window.removeWindowListener(listener)
+                window.removeWindowFocusListener(focusListener)
             }
+        }
+    }
+
+    LaunchedEffect(state.isShown) {
+        if (state.isShown) {
+            Desktop.getDesktop().requestForeground(true)
         }
     }
 }

--- a/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/Window.kt
+++ b/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/Window.kt
@@ -115,7 +115,7 @@ private fun PlatformWindow(
             }
             window.addWindowListener(listener)
 
-            // Hides the window if you focus from it.
+            // Hides the window when it loses focus.
             val focusListener = object : WindowAdapter() {
                 override fun windowLostFocus(e: WindowEvent?) {
                     state.isShown = false

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of the `Pingh` to publish.
  */
-val pinghVersion: String by extra("1.0.0-SNAPSHOT.32")
+val pinghVersion: String by extra("1.0.0-SNAPSHOT.33")


### PR DESCRIPTION
Previously, the application always remained on top of other windows, even when another application became active.

This changeset modifies the behavior of the application window. Now, when the application loses focus—such as after a click outside the window—it automatically minimizes. The application can be reopened by clicking its tray icon.

https://github.com/user-attachments/assets/f11f3d49-76cd-4ce4-a0d6-9d7a7d9cfa38