### PR TITLE
Prevent errors caused by duplicate mentions

### DIFF
--- a/client/src/main/kotlin/io/spine/examples/pingh/client/MentionsFlow.kt
+++ b/client/src/main/kotlin/io/spine/examples/pingh/client/MentionsFlow.kt
@@ -84,7 +84,9 @@ public class MentionsFlow internal constructor(
         ensureLoggedIn()
         val id = UserMentionsId::class.of(session.username)
         client.observeEntity(id, UserMentions::class) { entity ->
-            mentions.value = entity.mentionList.notIgnored()
+            mentions.value = entity.mentionList
+                .notIgnored()
+                .distinctBy { it.id }
         }
     }
 
@@ -117,6 +119,7 @@ public class MentionsFlow internal constructor(
         return userMentions
             ?.mentionList
             ?.notIgnored()
+            ?.distinctBy { it.id }
             ?: emptyList()
     }
 

--- a/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
+++ b/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://github.com/spine-examples/Pingh
 public object Pingh {
-    private const val version = "1.0.0-SNAPSHOT.37"
+    private const val version = "1.0.0-SNAPSHOT.38"
     private const val group = "io.spine.examples.pingh"
 
     public const val client: String = "$group:client:$version"

--- a/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/UserMentionsProjection.kt
+++ b/mentions/src/main/kotlin/io/spine/examples/pingh/mentions/UserMentionsProjection.kt
@@ -49,6 +49,9 @@ internal class UserMentionsProjection :
      */
     @Subscribe
     internal fun on(event: UserMentioned) {
+        if (state().mentionList.any { it.id.equals(event.id) }) {
+            return
+        }
         builder()
             .addMention(
                 MentionView::class.buildBy(event, MentionStatus.UNREAD)

--- a/mentions/src/test/kotlin/io/spine/examples/pingh/mentions/UserMentionsSpec.kt
+++ b/mentions/src/test/kotlin/io/spine/examples/pingh/mentions/UserMentionsSpec.kt
@@ -72,6 +72,12 @@ internal class UserMentionsSpec : ContextAwareTest() {
     }
 
     @Test
+    internal fun `ignore 'UserMentioned' event if mention with this ID already exists`() {
+        context().receivesEvent(userMentioned)
+        assertMentionStatus(MentionStatus.UNREAD)
+    }
+
+    @Test
     internal fun `react on 'MentionSnoozed' event, and mark the target mention as snoozed`() {
         val event = MentionSnoozed::class.buildBy(userMentioned.id)
         context().receivesEvent(event)

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of the `Pingh` to publish.
  */
-val pinghVersion: String by extra("1.0.0-SNAPSHOT.37")
+val pinghVersion: String by extra("1.0.0-SNAPSHOT.38")


### PR DESCRIPTION
A `LazyColumn` is used to display and animate mention cards on the Mentions page. Previously, a server [bug](https://github.com/spine-examples/Pingh/pull/66) led to duplicate mentions being stored in Datastore. As a result, attempting to open the application caused a crash, since `LazyColumn` does not support items with duplicate keys.

This changeset introduces an additional check to ignore duplicates when retrieving mentions, ensuring the application remains stable even in the presence of duplicate mention issues.