### PR TITLE
Add text card to Mentions page when there are no mentions

### DIFF
--- a/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
+++ b/desktop/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pingh.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://github.com/spine-examples/Pingh
 public object Pingh {
-    private const val version = "1.0.3"
+    private const val version = "1.0.4"
     private const val group = "io.spine.examples.pingh"
 
     public const val client: String = "$group:client:$version"

--- a/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/Mentions.kt
+++ b/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/Mentions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@file:Suppress("TooManyFunctions" /* Using Compose requires many functions to render the UI. */)
+
 package io.spine.examples.pingh.desktop
 
 import androidx.compose.animation.core.Spring.DampingRatioMediumBouncy
@@ -36,6 +38,7 @@ import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -52,6 +55,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Divider
+import androidx.compose.material.Surface
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults.cardColors
 import androidx.compose.material3.Icon
@@ -63,6 +67,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment.Companion.Center
+import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -74,6 +79,7 @@ import androidx.compose.ui.input.pointer.PointerIcon.Companion.Hand
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow.Companion.Ellipsis
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -253,16 +259,57 @@ private fun MentionCards(
 ) {
     val mentions by flow.mentions.collectAsState()
     val list = remember(mentions) { mentions.sorted() }
-    LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(10.dp)
-            .background(MaterialTheme.colorScheme.background)
-            .testTag("mention-cards"),
-        verticalArrangement = Arrangement.spacedBy(10.dp)
+    if (list.isEmpty()) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Center
+        ) {
+            NoMentionsCard()
+        }
+    } else {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(10.dp)
+                .background(MaterialTheme.colorScheme.background)
+                .testTag("mention-cards"),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            items(list.size, key = { index -> list[index].id }) { index ->
+                MentionCard(flow, list[index])
+            }
+        }
+    }
+}
+
+/**
+ * Displays a text card indicating that the user currently has no mentions.
+ */
+@Composable
+private fun NoMentionsCard() {
+    Surface(
+        modifier = Modifier.width(200.dp).height(70.dp),
+        shape = MaterialTheme.shapes.small,
+        color = MaterialTheme.colorScheme.secondary,
+        elevation = 5.dp
     ) {
-        items(list.size, key = { index -> list[index].id }) { index ->
-            MentionCard(flow, list[index])
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(5.dp, CenterVertically),
+            horizontalAlignment = CenterHorizontally
+        ) {
+            Text(
+                text = "No mentions yet.",
+                color = MaterialTheme.colorScheme.onSecondary,
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Text(
+                text = "Any new mentions will be displayed here as they appear.",
+                color = MaterialTheme.colorScheme.onSecondary,
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.bodyMedium
+            )
         }
     }
 }

--- a/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/Mentions.kt
+++ b/desktop/src/main/kotlin/io/spine/examples/pingh/desktop/Mentions.kt
@@ -67,7 +67,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment.Companion.Center
-import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -288,24 +287,17 @@ private fun MentionCards(
 @Composable
 private fun NoMentionsCard() {
     Surface(
-        modifier = Modifier.width(200.dp).height(70.dp),
+        modifier = Modifier.width(180.dp).height(50.dp),
         shape = MaterialTheme.shapes.small,
         color = MaterialTheme.colorScheme.secondary,
         elevation = 5.dp
     ) {
-        Column(
+        Box(
             modifier = Modifier.fillMaxSize(),
-            verticalArrangement = Arrangement.spacedBy(5.dp, CenterVertically),
-            horizontalAlignment = CenterHorizontally
+            contentAlignment = Center
         ) {
             Text(
-                text = "No mentions yet.",
-                color = MaterialTheme.colorScheme.onSecondary,
-                textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.bodyMedium
-            )
-            Text(
-                text = "Any new mentions will be displayed here as they appear.",
+                text = "No recent mentions yet.",
                 color = MaterialTheme.colorScheme.onSecondary,
                 textAlign = TextAlign.Center,
                 style = MaterialTheme.typography.bodyMedium

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -27,4 +27,4 @@
 /**
  * The version of the `Pingh` to publish.
  */
-val pinghVersion: String by extra("1.0.3")
+val pinghVersion: String by extra("1.0.4")


### PR DESCRIPTION
Previously, when a user had no mentions, the Mentions page appeared blank.

This changeset enhances the UI by adding a card to the Mentions page that informs the user when there are no mentions.

The Mentions page now appears as follows when there are no mentions:

<img width="457" alt="Screenshot 2025-01-24 at 12 36 45" src="https://github.com/user-attachments/assets/1133a4ef-869c-46e6-b516-c960cfb2c1ac" />